### PR TITLE
It's no use to set Header after WriteHeader called

### DIFF
--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"strconv"
 	"time"
 
 	"github.com/vulcand/oxy/utils"
@@ -113,10 +112,7 @@ func (f *Forwarder) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	utils.CopyHeaders(w.Header(), response.Header)
 	w.WriteHeader(response.StatusCode)
-	written, _ := io.Copy(w, response.Body)
-	if written != 0 {
-		w.Header().Set(ContentLength, strconv.FormatInt(written, 10))
-	}
+	io.Copy(w, response.Body)
 	response.Body.Close()
 }
 


### PR DESCRIPTION
As Go document said 

```
// Header returns the header map that will be sent by
// WriteHeader. Changing the header after a call to
// WriteHeader (or Write) has no effect unless the modified
// headers were declared as trailers by setting the
// "Trailer" header before the call to WriteHeader (see example).
// To suppress implicit response headers, set their value to nil.
```

https://github.com/golang/go/blob/aba6250250d0cdcd1b7a19ca9c6112639eccbb5e/src/net/http/server.go#L69

Set Header after write is no use, and in normal oxy's proxy situation Content-Type not change
