### PR TITLE
Handle error on io copy in forward

### DIFF
--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -113,7 +113,14 @@ func (f *Forwarder) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	utils.CopyHeaders(w.Header(), response.Header)
 	w.WriteHeader(response.StatusCode)
-	written, _ := io.Copy(w, response.Body)
+	written, err := io.Copy(w, response.Body)
+
+	if err != nil {
+		f.log.Errorf("Error copying upstream response Body: %v", err.Error())
+		f.errHandler.ServeHTTP(w, req, err)
+		return
+	}
+
 	if written != 0 {
 		w.Header().Set(ContentLength, strconv.FormatInt(written, 10))
 	}


### PR DESCRIPTION
Took us a while to track down. It caused issue #23 to happen for us. Turned out that the /tmp directory didn't exist in our scratch docker image.