### PR TITLE
Adding support for forwarding websocket traffic.

### DIFF
--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -1,13 +1,17 @@
 // package forwarder implements http handler that forwards requests to remote server
 // and serves back the response
+// websocket proxying support based on https://github.com/yhat/wsutil
 package forward
 
 import (
+	"crypto/tls"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/vulcand/oxy/utils"
@@ -20,6 +24,8 @@ type ReqRewriter interface {
 
 type optSetter func(f *Forwarder) error
 
+// PassHostHeader specifies if a client's Host header field should
+// be delegated
 func PassHostHeader(b bool) optSetter {
 	return func(f *Forwarder) error {
 		f.passHost = b
@@ -27,6 +33,8 @@ func PassHostHeader(b bool) optSetter {
 	}
 }
 
+// RoundTripper sets a new http.RoundTripper
+// Forwarder will use http.DefaultTransport as a default round tripper
 func RoundTripper(r http.RoundTripper) optSetter {
 	return func(f *Forwarder) error {
 		f.roundTripper = r
@@ -34,9 +42,18 @@ func RoundTripper(r http.RoundTripper) optSetter {
 	}
 }
 
+// Rewriter defines a request rewriter for the HTTP forwarder
 func Rewriter(r ReqRewriter) optSetter {
 	return func(f *Forwarder) error {
-		f.rewriter = r
+		f.httpForwarder.rewriter = r
+		return nil
+	}
+}
+
+// WebsocketRewriter defines a request rewriter for the websocket forwarder
+func WebsocketRewriter(r ReqRewriter) optSetter {
+	return func(f *Forwarder) error {
+		f.websocketForwarder.rewriter = r
 		return nil
 	}
 }
@@ -49,6 +66,8 @@ func ErrorHandler(h utils.ErrorHandler) optSetter {
 	}
 }
 
+// Logger specifies the logger to use.
+// Forwarder will default to oxyutils.NullLogger if no logger has been specified
 func Logger(l utils.Logger) optSetter {
 	return func(f *Forwarder) error {
 		f.log = l
@@ -56,30 +75,56 @@ func Logger(l utils.Logger) optSetter {
 	}
 }
 
+// Forwarder wraps two traffic forwarding implementations: HTTP and websockets.
+// It decides based on the specified request which implementation to use
 type Forwarder struct {
-	errHandler   utils.ErrorHandler
+	*httpForwarder
+	*websocketForwarder
+	*handlerContext
+}
+
+// handlerContext defines a handler context for error reporting and logging
+type handlerContext struct {
+	errHandler utils.ErrorHandler
+	log        utils.Logger
+}
+
+// httpForwarder is a handler that can reverse proxy
+// HTTP traffic
+type httpForwarder struct {
 	roundTripper http.RoundTripper
 	rewriter     ReqRewriter
-	log          utils.Logger
 	passHost     bool
 }
 
+// websocketForwarder is a handler that can reverse proxy
+// websocket traffic
+type websocketForwarder struct {
+	rewriter        ReqRewriter
+	TLSClientConfig *tls.Config
+}
+
+// New creates an instance of Forwarder based on the provided list of configuration options
 func New(setters ...optSetter) (*Forwarder, error) {
-	f := &Forwarder{}
+	f := &Forwarder{
+		httpForwarder:      &httpForwarder{},
+		websocketForwarder: &websocketForwarder{},
+		handlerContext:     &handlerContext{},
+	}
 	for _, s := range setters {
 		if err := s(f); err != nil {
 			return nil, err
 		}
 	}
-	if f.roundTripper == nil {
-		f.roundTripper = http.DefaultTransport
+	if f.httpForwarder.roundTripper == nil {
+		f.httpForwarder.roundTripper = http.DefaultTransport
 	}
-	if f.rewriter == nil {
+	if f.httpForwarder.rewriter == nil {
 		h, err := os.Hostname()
 		if err != nil {
 			h = "localhost"
 		}
-		f.rewriter = &HeaderRewriter{TrustForwardHeader: true, Hostname: h}
+		f.httpForwarder.rewriter = &HeaderRewriter{TrustForwardHeader: true, Hostname: h}
 	}
 	if f.log == nil {
 		f.log = utils.NullLogger
@@ -90,44 +135,57 @@ func New(setters ...optSetter) (*Forwarder, error) {
 	return f, nil
 }
 
+// ServeHTTP decides which forwarder to use based on the specified
+// request and delegates to the proper implementation
 func (f *Forwarder) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if isWebsocketRequest(req) {
+		f.websocketForwarder.serveHTTP(w, req, f.handlerContext)
+	} else {
+		f.httpForwarder.serveHTTP(w, req, f.handlerContext)
+	}
+}
+
+// serveHTTP forwards HTTP traffic using the configured transport
+func (f *httpForwarder) serveHTTP(w http.ResponseWriter, req *http.Request, ctx *handlerContext) {
 	start := time.Now().UTC()
 	response, err := f.roundTripper.RoundTrip(f.copyRequest(req, req.URL))
 	if err != nil {
-		f.log.Errorf("Error forwarding to %v, err: %v", req.URL, err)
-		f.errHandler.ServeHTTP(w, req, err)
+		ctx.log.Errorf("Error forwarding to %v, err: %v", req.URL, err)
+		ctx.errHandler.ServeHTTP(w, req, err)
 		return
 	}
 
 	if req.TLS != nil {
-		f.log.Infof("Round trip: %v, code: %v, duration: %v tls:version: %x, tls:resume:%t, tls:csuite:%x, tls:server:%v",
+		ctx.log.Infof("Round trip: %v, code: %v, duration: %v tls:version: %x, tls:resume:%t, tls:csuite:%x, tls:server:%v",
 			req.URL, response.StatusCode, time.Now().UTC().Sub(start),
 			req.TLS.Version,
 			req.TLS.DidResume,
 			req.TLS.CipherSuite,
 			req.TLS.ServerName)
 	} else {
-		f.log.Infof("Round trip: %v, code: %v, duration: %v",
+		ctx.log.Infof("Round trip: %v, code: %v, duration: %v",
 			req.URL, response.StatusCode, time.Now().UTC().Sub(start))
 	}
 
 	utils.CopyHeaders(w.Header(), response.Header)
 	w.WriteHeader(response.StatusCode)
 	written, err := io.Copy(w, response.Body)
+	defer response.Body.Close()
 
 	if err != nil {
-		f.log.Errorf("Error copying upstream response Body: %v", err.Error())
-		f.errHandler.ServeHTTP(w, req, err)
+		ctx.log.Errorf("Error copying upstream response Body: %v", err)
+		ctx.errHandler.ServeHTTP(w, req, err)
 		return
 	}
 
 	if written != 0 {
 		w.Header().Set(ContentLength, strconv.FormatInt(written, 10))
 	}
-	response.Body.Close()
 }
 
-func (f *Forwarder) copyRequest(req *http.Request, u *url.URL) *http.Request {
+// copyRequest makes a copy of the specified request to be sent using the configured
+// transport
+func (f *httpForwarder) copyRequest(req *http.Request, u *url.URL) *http.Request {
 	outReq := new(http.Request)
 	*outReq = *req // includes shallow copies of maps, but we handle this below
 
@@ -138,7 +196,7 @@ func (f *Forwarder) copyRequest(req *http.Request, u *url.URL) *http.Request {
 	// raw query is already included in RequestURI, so ignore it to avoid dupes
 	outReq.URL.RawQuery = ""
 	// Do not pass client Host header unless optsetter PassHostHeader is set.
-	if f.passHost != true {
+	if f.passHost {
 		outReq.Host = u.Host
 	}
 	outReq.Proto = "HTTP/1.1"
@@ -155,4 +213,91 @@ func (f *Forwarder) copyRequest(req *http.Request, u *url.URL) *http.Request {
 		f.rewriter.Rewrite(outReq)
 	}
 	return outReq
+}
+
+// serveHTTP forwards websocket traffic
+func (f *websocketForwarder) serveHTTP(w http.ResponseWriter, req *http.Request, ctx *handlerContext) {
+	outReq := f.copyRequest(req)
+	host := outReq.URL.Host
+	dial := net.Dial
+
+	// if host does not specify a port, use the default http port
+	if !strings.Contains(host, ":") {
+		if outReq.URL.Scheme == "wss" {
+			host = host + ":443"
+		} else {
+			host = host + ":80"
+		}
+	}
+
+	if outReq.URL.Scheme == "wss" {
+		if f.TLSClientConfig == nil {
+			f.TLSClientConfig = &tls.Config{}
+		}
+		dial = func(network, address string) (net.Conn, error) {
+			return tls.Dial("tcp", host, f.TLSClientConfig)
+		}
+	}
+
+	targetConn, err := dial("tcp", host)
+	if err != nil {
+		ctx.log.Errorf("Error dialing `%v`: %v", host, err)
+		ctx.errHandler.ServeHTTP(w, req, err)
+		return
+	}
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		ctx.log.Errorf("Unable to hijack the connection: %v", err)
+		ctx.errHandler.ServeHTTP(w, req, err)
+		return
+	}
+	underlyingConn, _, err := hijacker.Hijack()
+	if err != nil {
+		ctx.log.Errorf("Unable to hijack the connection: %v", err)
+		ctx.errHandler.ServeHTTP(w, req, err)
+		return
+	}
+	// it is now caller's responsibility to Close the underlying connection
+	defer underlyingConn.Close()
+	defer targetConn.Close()
+
+	// write the modified incoming request to the dialed connection
+	if err = outReq.Write(targetConn); err != nil {
+		ctx.log.Errorf("Unable to copy request to target: %v", err)
+		ctx.errHandler.ServeHTTP(w, req, err)
+		return
+	}
+	errc := make(chan error, 2)
+	replicate := func(dst io.Writer, src io.Reader) {
+		_, err := io.Copy(dst, src)
+		errc <- err
+	}
+	go replicate(targetConn, underlyingConn)
+	go replicate(underlyingConn, targetConn)
+	<-errc
+}
+
+// copyRequest makes a copy of the specified request.
+func (f *websocketForwarder) copyRequest(req *http.Request) (outReq *http.Request) {
+	outReq = new(http.Request)
+	*outReq = *req
+	outReq.URL = utils.CopyURL(req.URL)
+	outReq.URL.Scheme = req.URL.Scheme
+	outReq.URL.Host = req.URL.Host
+	return outReq
+}
+
+// isWebsocketRequest determines if the specified HTTP request is a
+// websocket handshake request
+func isWebsocketRequest(req *http.Request) bool {
+	containsHeader := func(name, value string) bool {
+		items := strings.Split(req.Header.Get(name), ",")
+		for _, item := range items {
+			if value == strings.ToLower(strings.TrimSpace(item)) {
+				return true
+			}
+		}
+		return false
+	}
+	return containsHeader(Connection, "upgrade") && containsHeader(Upgrade, "websocket")
 }

--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -196,7 +196,7 @@ func (f *httpForwarder) copyRequest(req *http.Request, u *url.URL) *http.Request
 	// raw query is already included in RequestURI, so ignore it to avoid dupes
 	outReq.URL.RawQuery = ""
 	// Do not pass client Host header unless optsetter PassHostHeader is set.
-	if f.passHost {
+	if !f.passHost {
 		outReq.Host = u.Host
 	}
 	outReq.Proto = "HTTP/1.1"

--- a/forward/fwd_test.go
+++ b/forward/fwd_test.go
@@ -3,6 +3,7 @@ package forward
 import (
 	"bytes"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -12,6 +13,7 @@ import (
 	"github.com/vulcand/oxy/testutils"
 	"github.com/vulcand/oxy/utils"
 
+	"golang.org/x/net/websocket"
 	. "gopkg.in/check.v1"
 )
 
@@ -34,7 +36,7 @@ func (s *FwdSuite) TestForwardHopHeaders(c *C) {
 	})
 	defer srv.Close()
 
-	f, err := New()
+	f, err := New(PassHostHeader(true))
 	c.Assert(err, IsNil)
 
 	proxy := testutils.NewHandler(func(w http.ResponseWriter, req *http.Request) {
@@ -286,4 +288,85 @@ func (s *FwdSuite) TestChunkedResponseConversion(c *C) {
 	c.Assert(string(body), Equals, "testtest1test2")
 	c.Assert(re.StatusCode, Equals, http.StatusOK)
 	c.Assert(re.Header.Get("Content-Length"), Equals, fmt.Sprintf("%d", len("testtest1test2")))
+}
+
+func (s *FwdSuite) TestDetectsWebsocketRequest(c *C) {
+	mux := http.NewServeMux()
+	mux.Handle("/ws", websocket.Handler(func(conn *websocket.Conn) {
+		conn.Write([]byte("ok"))
+		conn.Close()
+	}))
+	wsHandler := func(w http.ResponseWriter, req *http.Request) {
+		websocketRequest := isWebsocketRequest(req)
+		c.Assert(websocketRequest, Equals, true)
+		mux.ServeHTTP(w, req)
+	}
+	server := httptest.NewServer(http.HandlerFunc(wsHandler))
+	defer server.Close()
+
+	serverAddr := server.Listener.Addr().String()
+	resp, err := sendWebsocketRequest(serverAddr, "/ws", "echo", c)
+	c.Assert(err, IsNil)
+	c.Assert(resp, Equals, "ok")
+}
+
+func (s *FwdSuite) TestForwardsWebsocketTraffic(c *C) {
+	f, err := New()
+	c.Assert(err, IsNil)
+
+	mux := http.NewServeMux()
+	mux.Handle("/ws", websocket.Handler(func(conn *websocket.Conn) {
+		conn.Write([]byte("ok"))
+		conn.Close()
+	}))
+	srv := testutils.NewHandler(func(w http.ResponseWriter, req *http.Request) {
+		mux.ServeHTTP(w, req)
+	})
+	defer srv.Close()
+
+	proxy := testutils.NewHandler(func(w http.ResponseWriter, req *http.Request) {
+		path := req.URL.Path // keep the original path
+		// Set new backend URL
+		req.URL = testutils.ParseURI(srv.URL)
+		req.URL.Path = path
+		f.ServeHTTP(w, req)
+	})
+	defer proxy.Close()
+
+	proxyAddr := proxy.Listener.Addr().String()
+	resp, err := sendWebsocketRequest(proxyAddr, "/ws", "echo", c)
+	c.Assert(err, IsNil)
+	c.Assert(resp, Equals, "ok")
+}
+
+const dialTimeout = time.Second
+
+func sendWebsocketRequest(serverAddr, path, data string, c *C) (received string, err error) {
+	client, err := net.DialTimeout("tcp", serverAddr, dialTimeout)
+	if err != nil {
+		return "", err
+	}
+	config := newWebsocketConfig(serverAddr, path)
+	conn, err := websocket.NewClient(config, client)
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+	if _, err := conn.Write([]byte(data)); err != nil {
+		return "", err
+	}
+	var msg = make([]byte, 512)
+	var n int
+	n, err = conn.Read(msg)
+	if err != nil {
+		return "", err
+	}
+
+	received = string(msg[:n])
+	return received, nil
+}
+
+func newWebsocketConfig(serverAddr, path string) *websocket.Config {
+	config, _ := websocket.NewConfig(fmt.Sprintf("ws://%s%s", serverAddr, path), "http://localhost")
+	return config
 }

--- a/forward/fwd_test.go
+++ b/forward/fwd_test.go
@@ -36,7 +36,7 @@ func (s *FwdSuite) TestForwardHopHeaders(c *C) {
 	})
 	defer srv.Close()
 
-	f, err := New(PassHostHeader(true))
+	f, err := New()
 	c.Assert(err, IsNil)
 
 	proxy := testutils.NewHandler(func(w http.ResponseWriter, req *http.Request) {
@@ -296,15 +296,14 @@ func (s *FwdSuite) TestDetectsWebsocketRequest(c *C) {
 		conn.Write([]byte("ok"))
 		conn.Close()
 	}))
-	wsHandler := func(w http.ResponseWriter, req *http.Request) {
+	srv := testutils.NewHandler(func(w http.ResponseWriter, req *http.Request) {
 		websocketRequest := isWebsocketRequest(req)
 		c.Assert(websocketRequest, Equals, true)
 		mux.ServeHTTP(w, req)
-	}
-	server := httptest.NewServer(http.HandlerFunc(wsHandler))
-	defer server.Close()
+	})
+	defer srv.Close()
 
-	serverAddr := server.Listener.Addr().String()
+	serverAddr := srv.Listener.Addr().String()
 	resp, err := sendWebsocketRequest(serverAddr, "/ws", "echo", c)
 	c.Assert(err, IsNil)
 	c.Assert(resp, Equals, "ok")


### PR DESCRIPTION
The support is based on ideas from https://groups.google.com/d/msg/golang-nuts/KBx9pDlvFOc/QC5v-uC5UOgJ and https://github.com/yhat/wsutil but features a simplified interface.
Note, that due to implicit handling of backend URLs (as opposed to using a `Director` abstraction like `net/http/httputil.ReverseProxy`'s), `Forwarder.ServeHTTP` expects the backend server's URL in `http.Request` it receives, so care should be taken to preserve the original URL's details like Path.