### PR TITLE
remove the extra var duration(tim.duration)

### DIFF
--- a/cbreaker/cbreaker.go
+++ b/cbreaker/cbreaker.go
@@ -42,7 +42,6 @@ type CircuitBreaker struct {
 	metrics *memmetrics.RTMetrics
 
 	condition hpredicate
-	duration  time.Duration
 
 	fallbackDuration time.Duration
 	recoveryDuration time.Duration


### PR DESCRIPTION
i read the source code, but i can not find any function that variable  duration make.