### PR TITLE
Add layer 7 persistence / cookie sticky session support

### DIFF
--- a/cbreaker/cbreaker.go
+++ b/cbreaker/cbreaker.go
@@ -31,9 +31,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/mailgun/timetools"
 	"github.com/vulcand/oxy/memmetrics"
 	"github.com/vulcand/oxy/utils"
-	"github.com/mailgun/timetools"
 )
 
 // CircuitBreaker is http.Handler that implements circuit breaker pattern

--- a/cbreaker/cbreaker_test.go
+++ b/cbreaker/cbreaker_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mailgun/timetools"
 	"github.com/vulcand/oxy/memmetrics"
 	"github.com/vulcand/oxy/testutils"
-	"github.com/mailgun/timetools"
 
 	. "gopkg.in/check.v1"
 )

--- a/cbreaker/effect.go
+++ b/cbreaker/effect.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/mailgun/log"
 	"github.com/vulcand/oxy/utils"
 )
 
@@ -69,10 +68,9 @@ func (w *WebhookSideEffect) Exec() error {
 	if re.Body != nil {
 		defer re.Body.Close()
 	}
-	body, err := ioutil.ReadAll(re.Body)
+	_, err = ioutil.ReadAll(re.Body)
 	if err != nil {
 		return err
 	}
-	log.Infof("%v got response: (%s): %s", w, re.Status, string(body))
 	return nil
 }

--- a/cbreaker/ratio.go
+++ b/cbreaker/ratio.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/mailgun/log"
 	"github.com/mailgun/timetools"
 )
 
@@ -34,17 +33,14 @@ func (r *ratioController) String() string {
 }
 
 func (r *ratioController) allowRequest() bool {
-	log.Infof("%v", r)
 	t := r.targetRatio()
 	// This condition answers the question - would we satisfy the target ratio if we allow this request?
 	e := r.computeRatio(r.allowed+1, r.denied)
 	if e < t {
 		r.allowed++
-		log.Infof("%v allowed", r)
 		return true
 	}
 	r.denied++
-	log.Infof("%v denied", r)
 	return false
 }
 

--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -170,7 +170,13 @@ func (f *httpForwarder) serveHTTP(w http.ResponseWriter, req *http.Request, ctx 
 	utils.RemoveHeaders(w.Header(), HopHeaders...)
 	w.WriteHeader(response.StatusCode)
 
-	stream := "text/event-stream" == response.Header.Get(ContentType) || f.streamResponse
+	stream := f.streamResponse
+	if ! stream {
+		contentType, err := utils.GetHeaderMediaType(response.Header, ContentType)
+		if err == nil {
+			stream = contentType == "text/event-stream"
+		}
+	}
 	written, err := io.Copy(newResponseFlusher(w, stream), response.Body)
 
 	if req.TLS != nil {

--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -168,18 +167,16 @@ func (f *httpForwarder) serveHTTP(w http.ResponseWriter, req *http.Request, ctx 
 	}
 
 	utils.CopyHeaders(w.Header(), response.Header)
+	// Remove hop-by-hop headers.
+	utils.RemoveHeaders(w.Header(), HopHeaders...)
 	w.WriteHeader(response.StatusCode)
-	written, err := io.Copy(w, response.Body)
+	_, err = io.Copy(w, response.Body)
 	defer response.Body.Close()
 
 	if err != nil {
 		ctx.log.Errorf("Error copying upstream response Body: %v", err)
 		ctx.errHandler.ServeHTTP(w, req, err)
 		return
-	}
-
-	if written != 0 {
-		w.Header().Set(ContentLength, strconv.FormatInt(written, 10))
 	}
 }
 

--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"reflect"
 	"strings"
 	"time"
 
@@ -244,13 +245,13 @@ func (f *websocketForwarder) serveHTTP(w http.ResponseWriter, req *http.Request,
 	}
 	hijacker, ok := w.(http.Hijacker)
 	if !ok {
-		ctx.log.Errorf("Unable to hijack the connection: %v", err)
-		ctx.errHandler.ServeHTTP(w, req, err)
+		ctx.log.Errorf("Unable to hijack the connection: %v", reflect.TypeOf(w))
+		ctx.errHandler.ServeHTTP(w, req, nil)
 		return
 	}
 	underlyingConn, _, err := hijacker.Hijack()
 	if err != nil {
-		ctx.log.Errorf("Unable to hijack the connection: %v", err)
+		ctx.log.Errorf("Unable to hijack the connection: %v %v", reflect.TypeOf(w), err)
 		ctx.errHandler.ServeHTTP(w, req, err)
 		return
 	}

--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -171,13 +172,17 @@ func (f *httpForwarder) serveHTTP(w http.ResponseWriter, req *http.Request, ctx 
 	// Remove hop-by-hop headers.
 	utils.RemoveHeaders(w.Header(), HopHeaders...)
 	w.WriteHeader(response.StatusCode)
-	_, err = io.Copy(w, response.Body)
+	written, err := io.Copy(w, response.Body)
 	defer response.Body.Close()
 
 	if err != nil {
 		ctx.log.Errorf("Error copying upstream response Body: %v", err)
 		ctx.errHandler.ServeHTTP(w, req, err)
 		return
+	}
+
+	if written != 0 {
+		w.Header().Set(ContentLength, strconv.FormatInt(written, 10))
 	}
 }
 

--- a/forward/headers.go
+++ b/forward/headers.go
@@ -14,6 +14,7 @@ const (
 	TransferEncoding   = "Transfer-Encoding"
 	Upgrade            = "Upgrade"
 	ContentLength      = "Content-Length"
+	ContentType        = "Content-Type"
 )
 
 // Hop-by-hop headers. These are removed when sent to the backend.

--- a/forward/responseflusher.go
+++ b/forward/responseflusher.go
@@ -1,0 +1,53 @@
+package forward
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"net/http"
+)
+
+var (
+	_ http.Hijacker      = &responseFlusher{}
+	_ http.Flusher       = &responseFlusher{}
+	_ http.CloseNotifier = &responseFlusher{}
+)
+
+type responseFlusher struct {
+	http.ResponseWriter
+	flush bool
+}
+
+func newResponseFlusher(rw http.ResponseWriter, flush bool) *responseFlusher {
+	return &responseFlusher{
+		ResponseWriter: rw,
+		flush:          flush,
+	}
+}
+
+func (wf *responseFlusher) Write(p []byte) (int, error) {
+	written, err := wf.ResponseWriter.Write(p)
+	if wf.flush {
+		wf.Flush()
+	}
+	return written, err
+}
+
+func (wf *responseFlusher) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hijacker, ok := wf.ResponseWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, fmt.Errorf("the ResponseWriter doesn't support the Hijacker interface")
+	}
+	return hijacker.Hijack()
+}
+
+func (wf *responseFlusher) CloseNotify() <-chan bool {
+	return wf.ResponseWriter.(http.CloseNotifier).CloseNotify()
+}
+
+func (wf *responseFlusher) Flush() {
+	flusher, ok := wf.ResponseWriter.(http.Flusher)
+	if ok {
+		flusher.Flush()
+	}
+}

--- a/ratelimit/tokenlimiter_test.go
+++ b/ratelimit/tokenlimiter_test.go
@@ -7,9 +7,9 @@ import (
 	"net/http/httptest"
 	"time"
 
+	"github.com/mailgun/timetools"
 	"github.com/vulcand/oxy/testutils"
 	"github.com/vulcand/oxy/utils"
-	"github.com/mailgun/timetools"
 
 	. "gopkg.in/check.v1"
 )

--- a/roundrobin/rebalancer.go
+++ b/roundrobin/rebalancer.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/mailgun/timetools"
 	"github.com/vulcand/oxy/memmetrics"
 	"github.com/vulcand/oxy/utils"
-	"github.com/mailgun/timetools"
 )
 
 // RebalancerOption - functional option setter for rebalancer

--- a/roundrobin/rebalancer_test.go
+++ b/roundrobin/rebalancer_test.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"time"
 
+	"github.com/mailgun/timetools"
 	"github.com/vulcand/oxy/forward"
 	"github.com/vulcand/oxy/testutils"
 	"github.com/vulcand/oxy/utils"
-	"github.com/mailgun/timetools"
 
 	. "gopkg.in/check.v1"
 )

--- a/roundrobin/stickysessions.go
+++ b/roundrobin/stickysessions.go
@@ -1,0 +1,57 @@
+// package stickysession is a mixin for load balancers that implements layer 7 (http cookie) session affinity
+package roundrobin
+
+import (
+	"net/http"
+	"net/url"
+)
+
+type StickySession struct {
+	cookiename string
+}
+
+func NewStickySession(c string) *StickySession {
+	return &StickySession{c}
+}
+
+// GetBackend returns the backend URL stored in the sticky cookie, iff the backend is still in the valid list of servers.
+func (s *StickySession) GetBackend(req *http.Request, servers []*url.URL) (*url.URL, bool, error) {
+	cookie, err := req.Cookie(s.cookiename)
+	switch err {
+	case nil:
+	case http.ErrNoCookie:
+		return nil, false, nil
+	default:
+		return nil, false, err
+	}
+
+	s_url, err := url.Parse(cookie.Value)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if s.isBackendAlive(s_url, servers) {
+		return s_url, true, nil
+	} else {
+		return nil, false, nil
+	}
+}
+
+func (s *StickySession) StickBackend(backend *url.URL, w *http.ResponseWriter) {
+	c := &http.Cookie{Name: s.cookiename, Value: backend.String()}
+	http.SetCookie(*w, c)
+	return
+}
+
+func (s *StickySession) isBackendAlive(needle *url.URL, haystack []*url.URL) bool {
+	if len(haystack) == 0 {
+		return false
+	}
+
+	for _, s := range haystack {
+		if sameURL(needle, s) {
+			return true
+		}
+	}
+	return false
+}

--- a/roundrobin/stickysessions_test.go
+++ b/roundrobin/stickysessions_test.go
@@ -1,0 +1,237 @@
+package roundrobin
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/vulcand/oxy/forward"
+	"github.com/vulcand/oxy/testutils"
+
+	. "gopkg.in/check.v1"
+)
+
+func TestSS(t *testing.T) { TestingT(t) }
+
+type SSSuite struct{}
+
+var _ = Suite(&SSSuite{})
+
+func (s *SSSuite) TestBasic(c *C) {
+	a := testutils.NewResponder("a")
+	b := testutils.NewResponder("b")
+
+	defer a.Close()
+	defer b.Close()
+
+	fwd, err := forward.New()
+	c.Assert(err, IsNil)
+
+	sticky := NewStickySession("test")
+	c.Assert(sticky, NotNil)
+
+	lb, err := New(fwd, EnableStickySession(sticky))
+	c.Assert(err, IsNil)
+
+	lb.UpsertServer(testutils.ParseURI(a.URL))
+	lb.UpsertServer(testutils.ParseURI(b.URL))
+
+	proxy := httptest.NewServer(lb)
+	defer proxy.Close()
+
+	http_cli := &http.Client{}
+
+	for i := 0; i < 10; i++ {
+		req, err := http.NewRequest("GET", proxy.URL, nil)
+		c.Assert(err, IsNil)
+		req.AddCookie(&http.Cookie{Name: "test", Value: a.URL})
+
+		resp, err := http_cli.Do(req)
+		c.Assert(err, IsNil)
+
+		defer resp.Body.Close()
+		body, err := ioutil.ReadAll(resp.Body)
+
+		c.Assert(err, IsNil)
+		c.Assert(string(body), Equals, "a")
+	}
+}
+
+func (s *SSSuite) TestStickCookie(c *C) {
+	a := testutils.NewResponder("a")
+	b := testutils.NewResponder("b")
+
+	defer a.Close()
+	defer b.Close()
+
+	fwd, err := forward.New()
+	c.Assert(err, IsNil)
+
+	sticky := NewStickySession("test")
+	c.Assert(sticky, NotNil)
+
+	lb, err := New(fwd, EnableStickySession(sticky))
+	c.Assert(err, IsNil)
+
+	lb.UpsertServer(testutils.ParseURI(a.URL))
+	lb.UpsertServer(testutils.ParseURI(b.URL))
+
+	proxy := httptest.NewServer(lb)
+	defer proxy.Close()
+
+	resp, err := http.Get(proxy.URL)
+	c.Assert(err, IsNil)
+
+	c_out := resp.Cookies()[0]
+	c.Assert(c_out.Name, Equals, "test")
+	c.Assert(c_out.Value, Equals, a.URL)
+}
+
+func (s *SSSuite) TestRemoveRespondingServer(c *C) {
+	a := testutils.NewResponder("a")
+	b := testutils.NewResponder("b")
+
+	defer a.Close()
+	defer b.Close()
+
+	fwd, err := forward.New()
+	c.Assert(err, IsNil)
+
+	sticky := NewStickySession("test")
+	c.Assert(sticky, NotNil)
+
+	lb, err := New(fwd, EnableStickySession(sticky))
+	c.Assert(err, IsNil)
+
+	lb.UpsertServer(testutils.ParseURI(a.URL))
+	lb.UpsertServer(testutils.ParseURI(b.URL))
+
+	proxy := httptest.NewServer(lb)
+	defer proxy.Close()
+
+	http_cli := &http.Client{}
+
+	for i := 0; i < 10; i++ {
+		req, err := http.NewRequest("GET", proxy.URL, nil)
+		c.Assert(err, IsNil)
+		req.AddCookie(&http.Cookie{Name: "test", Value: a.URL})
+
+		resp, err := http_cli.Do(req)
+		c.Assert(err, IsNil)
+
+		defer resp.Body.Close()
+		body, err := ioutil.ReadAll(resp.Body)
+
+		c.Assert(err, IsNil)
+		c.Assert(string(body), Equals, "a")
+	}
+
+	lb.RemoveServer(testutils.ParseURI(a.URL))
+
+	// Now, use the organic cookie response in our next requests.
+	req, err := http.NewRequest("GET", proxy.URL, nil)
+	req.AddCookie(&http.Cookie{Name: "test", Value: a.URL})
+	resp, err := http_cli.Do(req)
+	c.Assert(err, IsNil)
+
+	c.Assert(resp.Cookies()[0].Name, Equals, "test")
+	c.Assert(resp.Cookies()[0].Value, Equals, b.URL)
+
+	for i := 0; i < 10; i++ {
+		req, err := http.NewRequest("GET", proxy.URL, nil)
+		c.Assert(err, IsNil)
+
+		resp, err := http_cli.Do(req)
+		c.Assert(err, IsNil)
+
+		defer resp.Body.Close()
+		body, err := ioutil.ReadAll(resp.Body)
+
+		c.Assert(err, IsNil)
+		c.Assert(string(body), Equals, "b")
+	}
+}
+
+func (s *SSSuite) TestRemoveAllServers(c *C) {
+	a := testutils.NewResponder("a")
+	b := testutils.NewResponder("b")
+
+	defer a.Close()
+	defer b.Close()
+
+	fwd, err := forward.New()
+	c.Assert(err, IsNil)
+
+	sticky := NewStickySession("test")
+	c.Assert(sticky, NotNil)
+
+	lb, err := New(fwd, EnableStickySession(sticky))
+	c.Assert(err, IsNil)
+
+	lb.UpsertServer(testutils.ParseURI(a.URL))
+	lb.UpsertServer(testutils.ParseURI(b.URL))
+
+	proxy := httptest.NewServer(lb)
+	defer proxy.Close()
+
+	http_cli := &http.Client{}
+
+	for i := 0; i < 10; i++ {
+		req, err := http.NewRequest("GET", proxy.URL, nil)
+		c.Assert(err, IsNil)
+		req.AddCookie(&http.Cookie{Name: "test", Value: a.URL})
+
+		resp, err := http_cli.Do(req)
+		c.Assert(err, IsNil)
+
+		defer resp.Body.Close()
+		body, err := ioutil.ReadAll(resp.Body)
+
+		c.Assert(err, IsNil)
+		c.Assert(string(body), Equals, "a")
+	}
+
+	lb.RemoveServer(testutils.ParseURI(a.URL))
+	lb.RemoveServer(testutils.ParseURI(b.URL))
+
+	// Now, use the organic cookie response in our next requests.
+	req, err := http.NewRequest("GET", proxy.URL, nil)
+	req.AddCookie(&http.Cookie{Name: "test", Value: a.URL})
+	resp, err := http_cli.Do(req)
+	c.Assert(err, IsNil)
+	c.Assert(resp.StatusCode, Equals, http.StatusInternalServerError)
+}
+
+func (s *SSSuite) TestBadCookieVal(c *C) {
+	a := testutils.NewResponder("a")
+	b := testutils.NewResponder("b")
+
+	defer a.Close()
+	defer b.Close()
+
+	fwd, err := forward.New()
+	c.Assert(err, IsNil)
+
+	sticky := NewStickySession("test")
+	c.Assert(sticky, NotNil)
+
+	lb, err := New(fwd, EnableStickySession(sticky))
+	c.Assert(err, IsNil)
+
+	lb.UpsertServer(testutils.ParseURI(a.URL))
+	lb.UpsertServer(testutils.ParseURI(b.URL))
+
+	proxy := httptest.NewServer(lb)
+	defer proxy.Close()
+
+	http_cli := &http.Client{}
+
+	req, err := http.NewRequest("GET", proxy.URL, nil)
+	c.Assert(err, IsNil)
+	req.AddCookie(&http.Cookie{Name: "test", Value: "http://[::1]a"}) // error value from go's net/url tests.
+
+	resp, err := http_cli.Do(req)
+	c.Assert(err, IsNil)
+	c.Assert(resp.StatusCode, Equals, http.StatusInternalServerError)
+}

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -8,8 +8,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
-
-	"github.com/vulcand/oxy/utils"
 )
 
 func NewHandler(handler http.HandlerFunc) *httptest.Server {

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -3,6 +3,7 @@ package testutils
 import (
 	"crypto/tls"
 	"fmt"
+	"github.com/vulcand/oxy/utils"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"

--- a/utils/netutils.go
+++ b/utils/netutils.go
@@ -1,7 +1,9 @@
 package utils
 
 import (
+	"bufio"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 )
@@ -42,6 +44,10 @@ func (p *ProxyWriter) Flush() {
 	}
 }
 
+func (p *ProxyWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return p.W.(http.Hijacker).Hijack()
+}
+
 func NewBufferWriter(w io.WriteCloser) *BufferWriter {
 	return &BufferWriter{
 		W: w,
@@ -70,6 +76,10 @@ func (b *BufferWriter) Write(buf []byte) (int, error) {
 // WriteHeader sets rw.Code.
 func (b *BufferWriter) WriteHeader(code int) {
 	b.Code = code
+}
+
+func (b *BufferWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return b.W.(http.Hijacker).Hijack()
 }
 
 type nopWriteCloser struct {

--- a/utils/netutils.go
+++ b/utils/netutils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"bufio"
 	"io"
+	"mime"
 	"net"
 	"net/http"
 	"net/url"
@@ -128,4 +129,10 @@ func RemoveHeaders(headers http.Header, names ...string) {
 	for _, h := range names {
 		headers.Del(h)
 	}
+}
+
+// Parse the MIME media type value of a header.
+func GetHeaderMediaType(headers http.Header, name string) (string, error)  {
+	mediatype, _, err := mime.ParseMediaType(headers.Get(name))
+	return mediatype, err
 }

--- a/utils/netutils_test.go
+++ b/utils/netutils_test.go
@@ -66,3 +66,30 @@ func (s *NetUtilsSuite) TestRemoveHeaders(c *C) {
 	c.Assert(source.Get("a"), Equals, "")
 	c.Assert(source.Get("c"), Equals, "d")
 }
+
+func (s *NetUtilsSuite) TestGetHeaderMediaType(c *C) {
+	source := make(http.Header)
+	source.Add("Content-Type", "text/event-stream")
+
+	mediatype, err := GetHeaderMediaType(source, "Content-Type")
+	c.Assert(err, IsNil)
+	c.Assert(mediatype, Equals, "text/event-stream")
+}
+
+func (s *NetUtilsSuite) TestGetHeaderMediaTypeCharSet(c *C) {
+	source := make(http.Header)
+	source.Add("Content-Type", "text/event-stream; charset=utf-8")
+
+	mediatype, err := GetHeaderMediaType(source, "Content-Type")
+	c.Assert(err, IsNil)
+	c.Assert(mediatype, Equals, "text/event-stream")
+}
+
+func (s *NetUtilsSuite) TestGetHeaderMediaTypeMixedCase(c *C) {
+	source := make(http.Header)
+	source.Add("Content-Type", "text/Event-Stream")
+
+	mediatype, err := GetHeaderMediaType(source, "Content-Type")
+	c.Assert(err, IsNil)
+	c.Assert(mediatype, Equals, "text/event-stream")
+}


### PR DESCRIPTION
I've been doing some work to try to get sticky sessions set up in Oxy's round robin.

To use, call `NewStickySession` with a cookie name.  Then when calling `rr.New`, pass `EnableStickySession` in to the options.  An server cookie (named as above) will be set and checked for future use.

This PR is against the base round robin only, for now.  I'm hoping to get an initial code review, and if you're interested, I'll keep fleshing this out against the rebalancing round robin.