### PR TITLE
Added the ability to hijack connections (for Websockets)

### DIFF
--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -17,6 +17,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/vulcand/oxy/utils"
 	"net/http/httputil"
+	"reflect"
 )
 
 // ReqRewriter can alter request headers and body
@@ -294,7 +295,7 @@ func (f *websocketForwarder) serveHTTP(w http.ResponseWriter, req *http.Request,
 	}
 	hijacker, ok := w.(http.Hijacker)
 	if !ok {
-		log.Errorf("Unable to hijack the connection: does not implement http.Hijacker")
+		log.Errorf("Unable to hijack the connection: does not implement http.Hijacker. ResponseWriter implementation type: %v", reflect.TypeOf(w))
 		ctx.errHandler.ServeHTTP(w, req, err)
 		return
 	}

--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -103,7 +103,7 @@ func (s *STSuite) TestChunkedEncodingSuccess(c *C) {
 
 	reader.ReadString('\n') //content type
 	reader.ReadString('\n') //Date
-	transferEncoding , _ := reader.ReadString('\n')
+	transferEncoding, _ := reader.ReadString('\n')
 
 	c.Assert(transferEncoding, Equals, "Transfer-Encoding: chunked\r\n")
 	c.Assert(contentLength, Equals, int64(-1))


### PR DESCRIPTION
During my web socket tests I realized that ProxyWriter
and BufferWriter didn't implement the http.Hijacker
interface.

Moreover, there wasn't sufficient debugging info in the logs
that told us which implementation of ResponseWriter was being used.

This information is necessary in the future when proxies
are injected and we need to quickly figure out where the gaps are.

I've added logs which emit the type of the implementer of an interface,
whenever it cannot be cast into a target interface.

I also implemented http.Hijacker on ProxyWriter and BufferWriter.