### PR TITLE
Change scheme for WS requests when backends might be registered as HTTP.

### DIFF
--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -18,7 +18,6 @@ import (
 	"github.com/vulcand/oxy/utils"
 	"net/http/httputil"
 	"reflect"
-	"fmt"
 )
 
 // ReqRewriter can alter request headers and body
@@ -325,7 +324,7 @@ func (f *websocketForwarder) serveHTTP(w http.ResponseWriter, req *http.Request,
 	}
 	go replicate(targetConn, underlyingConn)
 	go replicate(underlyingConn, targetConn)
-	<- errc
+	<-errc
 }
 
 // copyRequest makes a copy of the specified request.

--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -17,6 +17,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/vulcand/oxy/utils"
 	"net/http/httputil"
+	"reflect"
 )
 
 // ReqRewriter can alter request headers and body
@@ -294,7 +295,7 @@ func (f *websocketForwarder) serveHTTP(w http.ResponseWriter, req *http.Request,
 	}
 	hijacker, ok := w.(http.Hijacker)
 	if !ok {
-		log.Errorf("Unable to hijack the connection: does not implement http.Hijacker")
+		log.Errorf("Unable to hijack the connection: does not implement http.Hijacker. ResponseWriter implementation type: %v", reflect.TypeOf(w))
 		ctx.errHandler.ServeHTTP(w, req, err)
 		return
 	}

--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -103,7 +103,7 @@ func (s *STSuite) TestChunkedEncodingSuccess(c *C) {
 
 	reader.ReadString('\n') //content type
 	reader.ReadString('\n') //Date
-	transferEncoding , _ := reader.ReadString('\n')
+	transferEncoding, _ := reader.ReadString('\n')
 
 	c.Assert(transferEncoding, Equals, "Transfer-Encoding: chunked\r\n")
 	c.Assert(contentLength, Equals, int64(-1))


### PR DESCRIPTION
Because of the way backends might be registered to Vulcan,
and if a backend supports both http and web socket protocols,
it makes sense for the web socket forwarder to rewrite the
scheme correctly.

It IS possible to do this with multiple routes, but that's fickle
and difficult to maintain when not necessary.
