### PR TITLE
Logging revamp

### DIFF
--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -180,8 +180,12 @@ func (s *Buffer) Wrap(next http.Handler) error {
 }
 
 func (s *Buffer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	logEntry := log.WithField("Request", utils.DumpHttpRequest(req))
+	logEntry.Debug("vulcand/oxy/buffer: begin ServeHttp on request")
+	defer logEntry.Debug("vulcand/oxy/buffer: competed ServeHttp on request")
+
 	if err := s.checkLimit(req); err != nil {
-		log.Infof("request body over limit: %v", err)
+		log.Errorf("vulcand/oxy/buffer: request body over limit, err: %v", err)
 		s.errHandler.ServeHTTP(w, req, err)
 		return
 	}
@@ -192,6 +196,7 @@ func (s *Buffer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	// and the reader would be unbounded bufio in the http.Server
 	body, err := multibuf.New(req.Body, multibuf.MaxBytes(s.maxRequestBodyBytes), multibuf.MemBytes(s.memRequestBodyBytes))
 	if err != nil || body == nil {
+		log.Errorf("vulcand/oxy/buffer: error when reading request body, err: %v", err)
 		s.errHandler.ServeHTTP(w, req, err)
 		return
 	}
@@ -205,7 +210,7 @@ func (s *Buffer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	// set without content length or using chunked TransferEncoding
 	totalSize, err := body.Size()
 	if err != nil {
-		log.Errorf("failed to get size, err %v", err)
+		log.Errorf("vulcand/oxy/buffer: failed to get request size, err: %v", err)
 		s.errHandler.ServeHTTP(w, req, err)
 		return
 	}
@@ -217,6 +222,7 @@ func (s *Buffer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		// We create a special writer that will limit the response size, buffer it to disk if necessary
 		writer, err := multibuf.NewWriterOnce(multibuf.MaxBytes(s.maxResponseBodyBytes), multibuf.MemBytes(s.memResponseBodyBytes))
 		if err != nil {
+			log.Errorf("vulcand/oxy/buffer: failed create response writer, err: %v", err)
 			s.errHandler.ServeHTTP(w, req, err)
 			return
 		}
@@ -234,7 +240,7 @@ func (s *Buffer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		if b.expectBody(outreq) {
 			rdr, err := writer.Reader()
 			if err != nil {
-				log.Errorf("failed to read response, err %v", err)
+				log.Errorf("vulcand/oxy/buffer: failed to read response, err: %v", err)
 				s.errHandler.ServeHTTP(w, req, err)
 				return
 			}
@@ -254,12 +260,12 @@ func (s *Buffer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 		attempt += 1
 		if _, err := body.Seek(0, 0); err != nil {
-			log.Errorf("Failed to rewind: error: %v", err)
+			log.Errorf("vulcand/oxy/buffer: failed to rewind response body, err: %v", err)
 			s.errHandler.ServeHTTP(w, req, err)
 			return
 		}
 		outreq = s.copyRequest(req, body, totalSize)
-		log.Infof("retry Request(%v %v) attempt %v", req.Method, req.URL, attempt)
+		log.Infof("vulcand/oxy/buffer: retry Request(%v %v) attempt %v", req.Method, req.URL, attempt)
 	}
 }
 

--- a/cbreaker/cbreaker.go
+++ b/cbreaker/cbreaker.go
@@ -100,6 +100,9 @@ func New(next http.Handler, expression string, options ...CircuitBreakerOption) 
 }
 
 func (c *CircuitBreaker) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	logEntry := log.WithField("Request", utils.DumpHttpRequest(req))
+	logEntry.Debug("vulcand/oxy/circuitbreaker: begin ServeHttp on request")
+	defer logEntry.Debug("vulcand/oxy/circuitbreaker: competed ServeHttp on request")
 	if c.activateFallback(w, req) {
 		c.fallback.ServeHTTP(w, req)
 		return

--- a/cbreaker/fallback.go
+++ b/cbreaker/fallback.go
@@ -5,6 +5,9 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/vulcand/oxy/utils"
 )
 
 type Response struct {
@@ -25,6 +28,9 @@ func NewResponseFallback(r Response) (*ResponseFallback, error) {
 }
 
 func (f *ResponseFallback) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	logEntry := log.WithField("Request", utils.DumpHttpRequest(req))
+	logEntry.Debug("vulcand/oxy/fallback/response: begin ServeHttp on request")
+	defer logEntry.Debug("vulcand/oxy/fallback/response: competed ServeHttp on request")
 	if f.r.ContentType != "" {
 		w.Header().Set("Content-Type", f.r.ContentType)
 	}
@@ -50,6 +56,9 @@ func NewRedirectFallback(r Redirect) (*RedirectFallback, error) {
 }
 
 func (f *RedirectFallback) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	logEntry := log.WithField("Request", utils.DumpHttpRequest(req))
+	logEntry.Debug("vulcand/oxy/fallback/redirect: begin ServeHttp on request")
+	defer logEntry.Debug("vulcand/oxy/fallback/redirect: competed ServeHttp on request")
 	w.Header().Set("Location", f.u.String())
 	w.WriteHeader(http.StatusFound)
 	w.Write([]byte(http.StatusText(http.StatusFound)))

--- a/connlimit/connlimit.go
+++ b/connlimit/connlimit.go
@@ -107,6 +107,9 @@ type ConnErrHandler struct {
 }
 
 func (e *ConnErrHandler) ServeHTTP(w http.ResponseWriter, req *http.Request, err error) {
+	logEntry := log.WithField("Request", utils.DumpHttpRequest(req))
+	logEntry.Debug("vulcand/oxy/connlimit: begin ServeHttp on request")
+	defer logEntry.Debug("vulcand/oxy/connlimit: competed ServeHttp on request")
 	if _, ok := err.(*MaxConnError); ok {
 		w.WriteHeader(429)
 		w.Write([]byte(err.Error()))

--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -188,6 +188,10 @@ func New(setters ...optSetter) (*Forwarder, error) {
 // ServeHTTP decides which forwarder to use based on the specified
 // request and delegates to the proper implementation
 func (f *Forwarder) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	logEntry := log.WithField("Request", utils.DumpHttpRequest(req))
+	logEntry.Debug("vulcand/oxy/forward: begin ServeHttp on request")
+	defer logEntry.Debug("vulcand/oxy/forward: competed ServeHttp on request")
+
 	if f.stateListener != nil {
 		f.stateListener(req.URL, StateConnected)
 		defer f.stateListener(req.URL, StateDisconnected)
@@ -203,24 +207,27 @@ func (f *Forwarder) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 // serveHTTP forwards HTTP traffic using the configured transport
 func (f *httpForwarder) serveHTTP(w http.ResponseWriter, req *http.Request, ctx *handlerContext) {
+	logEntry := log.WithField("Request", utils.DumpHttpRequest(req))
+	logEntry.Debug("vulcand/oxy/forward/httpbuffer: begin ServeHttp on request")
+	defer logEntry.Debug("vulcand/oxy/forward/httpbuffer: competed ServeHttp on request")
 
 	start := time.Now().UTC()
 	response, err := f.roundTripper.RoundTrip(f.copyRequest(req, req.URL))
 	if err != nil {
-		log.Errorf("Error forwarding to %v, err: %v", req.URL, err)
+		log.Errorf("vulcand/oxy/forward/httpbuffer: Error forwarding to %v, err: %v", req.URL, err)
 		ctx.errHandler.ServeHTTP(w, req, err)
 		return
 	}
 
 	if req.TLS != nil {
-		log.Infof("Round trip: %v, code: %v, duration: %v tls:version: %x, tls:resume:%t, tls:csuite:%x, tls:server:%v",
+		log.Infof("vulcand/oxy/forward/httpbuffer: Round trip: %v, code: %v, duration: %v tls:version: %x, tls:resume:%t, tls:csuite:%x, tls:server:%v",
 			req.URL, response.StatusCode, time.Now().UTC().Sub(start),
 			req.TLS.Version,
 			req.TLS.DidResume,
 			req.TLS.CipherSuite,
 			req.TLS.ServerName)
 	} else {
-		log.Infof("Round trip: %v, code: %v, duration: %v",
+		log.Infof("vulcand/oxy/forward/httpbuffer: Round trip: %v, code: %v, duration: %v",
 			req.URL, response.StatusCode, time.Now().UTC().Sub(start))
 	}
 
@@ -231,7 +238,7 @@ func (f *httpForwarder) serveHTTP(w http.ResponseWriter, req *http.Request, ctx 
 	defer response.Body.Close()
 
 	if err != nil {
-		log.Errorf("Error copying upstream response Body: %v", err)
+		log.Errorf("vulcand/oxy/forward/httpbuffer: Error copying upstream response Body: %v", err)
 		ctx.errHandler.ServeHTTP(w, req, err)
 		return
 	}
@@ -275,6 +282,9 @@ func (f *httpForwarder) copyRequest(req *http.Request, u *url.URL) *http.Request
 
 // serveHTTP forwards websocket traffic
 func (f *websocketForwarder) serveHTTP(w http.ResponseWriter, req *http.Request, ctx *handlerContext) {
+	logEntry := log.WithField("Request", utils.DumpHttpRequest(req))
+	logEntry.Debug("vulcand/oxy/forward/websocket: begin ServeHttp on request")
+	defer logEntry.Debug("vulcand/oxy/forward/websocket: competed ServeHttp on request")
 	outReq := f.copyRequest(req)
 	host := outReq.URL.Host
 
@@ -289,19 +299,19 @@ func (f *websocketForwarder) serveHTTP(w http.ResponseWriter, req *http.Request,
 
 	targetConn, err := f.dial("tcp", host)
 	if err != nil {
-		log.Errorf("Error dialing `%v`: %v", host, err)
+		log.Errorf("vulcand/oxy/forward/websocket: Error dialing `%v`: %v", host, err)
 		ctx.errHandler.ServeHTTP(w, req, err)
 		return
 	}
 	hijacker, ok := w.(http.Hijacker)
 	if !ok {
-		log.Errorf("Unable to hijack the connection: does not implement http.Hijacker. ResponseWriter implementation type: %v", reflect.TypeOf(w))
+		log.Errorf("vulcand/oxy/forward/websocket: Unable to hijack the connection: does not implement http.Hijacker. ResponseWriter implementation type: %v", reflect.TypeOf(w))
 		ctx.errHandler.ServeHTTP(w, req, err)
 		return
 	}
 	underlyingConn, _, err := hijacker.Hijack()
 	if err != nil {
-		log.Errorf("Unable to hijack the connection: %v", err)
+		log.Errorf("vulcand/oxy/forward/websocket: Unable to hijack the connection: %v", err)
 		ctx.errHandler.ServeHTTP(w, req, err)
 		return
 	}
@@ -309,11 +319,11 @@ func (f *websocketForwarder) serveHTTP(w http.ResponseWriter, req *http.Request,
 	defer underlyingConn.Close()
 	defer targetConn.Close()
 
-	log.Infof("Writing outgoing Websocket request to target connection: %+v", outReq)
+	log.Infof("vulcand/oxy/forward/websocket: Writing outgoing Websocket request to target connection: %+v", outReq)
 
 	// write the modified incoming request to the dialed connection
 	if err = outReq.Write(targetConn); err != nil {
-		log.Errorf("Unable to copy request to target: %v", err)
+		log.Errorf("vulcand/oxy/forward/websocket: Unable to copy request to target: %v", err)
 		ctx.errHandler.ServeHTTP(w, req, err)
 		return
 	}
@@ -366,6 +376,9 @@ func isWebsocketRequest(req *http.Request) bool {
 
 // serveHTTP forwards HTTP traffic using the configured transport
 func (f *httpStreamingForwarder) serveHTTP(w http.ResponseWriter, req *http.Request, ctx *handlerContext) {
+	logEntry := log.WithField("Request", utils.DumpHttpRequest(req))
+	logEntry.Debug("vulcand/oxy/forward/httpstream: begin ServeHttp on request")
+	defer logEntry.Debug("vulcand/oxy/forward/httpstream: competed ServeHttp on request")
 	pw := &utils.ProxyWriter{
 		W: w,
 	}
@@ -390,14 +403,14 @@ func (f *httpStreamingForwarder) serveHTTP(w http.ResponseWriter, req *http.Requ
 	revproxy.ServeHTTP(pw, req)
 
 	if req.TLS != nil {
-		log.Infof("Round trip: %v, code: %v, Length: %v, duration: %v tls:version: %x, tls:resume:%t, tls:csuite:%x, tls:server:%v",
+		log.Infof("vulcand/oxy/forward/httpstream: Round trip: %v, code: %v, Length: %v, duration: %v tls:version: %x, tls:resume:%t, tls:csuite:%x, tls:server:%v",
 			req.URL, pw.Code, pw.Length, time.Now().UTC().Sub(start),
 			req.TLS.Version,
 			req.TLS.DidResume,
 			req.TLS.CipherSuite,
 			req.TLS.ServerName)
 	} else {
-		log.Infof("Round trip: %v, code: %v, Length: %v, duration: %v",
+		log.Infof("vulcand/oxy/forward/httpstream: Round trip: %v, code: %v, Length: %v, duration: %v",
 			req.URL, pw.Code, pw.Length, time.Now().UTC().Sub(start))
 	}
 }

--- a/roundrobin/rebalancer.go
+++ b/roundrobin/rebalancer.go
@@ -121,6 +121,9 @@ func (rb *Rebalancer) Servers() []*url.URL {
 }
 
 func (rb *Rebalancer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	logEntry := log.WithField("Request", utils.DumpHttpRequest(req))
+	logEntry.Debug("vulcand/oxy/roundrobin/rebalancer: begin ServeHttp on request")
+	defer logEntry.Debug("vulcand/oxy/roundrobin/rebalancer: competed ServeHttp on request")
 	pw := &utils.ProxyWriter{W: w}
 	start := rb.clock.UtcNow()
 	url, err := rb.next.NextServer()
@@ -128,6 +131,9 @@ func (rb *Rebalancer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		rb.errHandler.ServeHTTP(w, req, err)
 		return
 	}
+
+	//log which backend URL we're sending this request to
+	log.WithFields(log.Fields{"Request": utils.DumpHttpRequest(req), "ForwardURL": url}).Info("vulcand/oxy/roundrobin/rebalancer: Forwarding this request to URL")
 
 	// make shallow copy of request before changing anything to avoid side effects
 	newReq := *req

--- a/roundrobin/rr.go
+++ b/roundrobin/rr.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"sync"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/vulcand/oxy/utils"
 )
 
@@ -62,11 +63,18 @@ func (r *RoundRobin) Next() http.Handler {
 }
 
 func (r *RoundRobin) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	logEntry := log.WithField("Request", utils.DumpHttpRequest(req))
+	logEntry.Debug("vulcand/oxy/roundrobin/rr: begin ServeHttp on request")
+	defer logEntry.Debug("vulcand/oxy/roundrobin/rr: competed ServeHttp on request")
 	url, err := r.NextServer()
 	if err != nil {
 		r.errHandler.ServeHTTP(w, req, err)
 		return
 	}
+
+	//log which backend URL we're sending this request to
+	log.WithFields(log.Fields{"Request": utils.DumpHttpRequest(req), "ForwardURL": url}).Info("vulcand/oxy/roundrobin/rr: Forwarding this request to URL")
+
 	// make shallow copy of request before chaning anything to avoid side effects
 	newReq := *req
 	newReq.URL = url

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -34,6 +34,7 @@ package stream
 import (
 	"net/http"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/vulcand/oxy/utils"
 )
 
@@ -81,5 +82,8 @@ func (s *Stream) Wrap(next http.Handler) error {
 }
 
 func (s *Stream) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	logEntry := log.WithField("Request", utils.DumpHttpRequest(req))
+	logEntry.Debug("vulcand/oxy/stream: begin ServeHttp on request")
+	defer logEntry.Debug("vulcand/oxy/stream: competed ServeHttp on request")
 	s.next.ServeHTTP(w, req)
 }

--- a/utils/dumpreq.go
+++ b/utils/dumpreq.go
@@ -1,0 +1,60 @@
+package utils
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+)
+
+type SerializableHttpRequest struct {
+	Method           string
+	URL              *url.URL
+	Proto            string // "HTTP/1.0"
+	ProtoMajor       int    // 1
+	ProtoMinor       int    // 0
+	Header           http.Header
+	ContentLength    int64
+	TransferEncoding []string
+	Host             string
+	Form             url.Values
+	PostForm         url.Values
+	MultipartForm    *multipart.Form
+	Trailer          http.Header
+	RemoteAddr       string
+	RequestURI       string
+	TLS              *tls.ConnectionState
+}
+
+func Clone(r *http.Request) *SerializableHttpRequest {
+	if r == nil {
+		return nil
+	}
+
+	rc := new(SerializableHttpRequest)
+	rc.Method = r.Method
+	rc.URL = r.URL
+	rc.Proto = r.Proto
+	rc.ProtoMajor = r.ProtoMajor
+	rc.ProtoMinor = r.ProtoMinor
+	rc.Header = r.Header
+	rc.ContentLength = r.ContentLength
+	rc.Host = r.Host
+	rc.RemoteAddr = r.RemoteAddr
+	rc.RequestURI = r.RequestURI
+	return rc
+}
+
+func (s *SerializableHttpRequest) ToJson() string {
+	if jsonVal, err := json.Marshal(s); err != nil || jsonVal == nil {
+		return fmt.Sprintf("Error marshalling SerializableHttpRequest to json: %s", err.Error())
+	} else {
+		return string(jsonVal)
+	}
+}
+
+func DumpHttpRequest(req *http.Request) string {
+	return fmt.Sprintf("%v", Clone(req).ToJson())
+}

--- a/utils/dumpreq_test.go
+++ b/utils/dumpreq_test.go
@@ -1,0 +1,36 @@
+package utils
+
+import (
+	. "gopkg.in/check.v1"
+	"net/http"
+	"net/url"
+)
+
+type DumpHttpReqSuite struct {
+}
+
+var _ = Suite(&DumpHttpReqSuite{})
+
+type readCloserTestImpl struct {
+}
+
+func (r *readCloserTestImpl) Read(p []byte) (n int, err error) {
+	return 0, nil
+}
+
+func (r *readCloserTestImpl) Close() error {
+	return nil
+}
+
+//Just to make sure we don't panic, return err and not
+//username and pass and cover the function
+func (s *DumpHttpReqSuite) TestHttpReqToString(c *C) {
+	req := &http.Request{
+		URL:    &url.URL{Host: "localhost:2374", Path: "/unittest"},
+		Method: "DELETE",
+		Cancel: make(chan struct{}),
+		Body:   &readCloserTestImpl{},
+	}
+
+	c.Assert(DumpHttpRequest(req), Equals, "{\"Method\":\"DELETE\",\"URL\":{\"Scheme\":\"\",\"Opaque\":\"\",\"User\":null,\"Host\":\"localhost:2374\",\"Path\":\"/unittest\",\"RawPath\":\"\",\"ForceQuery\":false,\"RawQuery\":\"\",\"Fragment\":\"\"},\"Proto\":\"\",\"ProtoMajor\":0,\"ProtoMinor\":0,\"Header\":null,\"ContentLength\":0,\"TransferEncoding\":null,\"Host\":\"\",\"Form\":null,\"PostForm\":null,\"MultipartForm\":null,\"Trailer\":null,\"RemoteAddr\":\"\",\"RequestURI\":\"\",\"TLS\":null}")
+}

--- a/utils/dumpreq_test.go
+++ b/utils/dumpreq_test.go
@@ -32,5 +32,5 @@ func (s *DumpHttpReqSuite) TestHttpReqToString(c *C) {
 		Body:   &readCloserTestImpl{},
 	}
 
-	c.Assert(DumpHttpRequest(req), Equals, "{\"Method\":\"DELETE\",\"URL\":{\"Scheme\":\"\",\"Opaque\":\"\",\"User\":null,\"Host\":\"localhost:2374\",\"Path\":\"/unittest\",\"RawPath\":\"\",\"ForceQuery\":false,\"RawQuery\":\"\",\"Fragment\":\"\"},\"Proto\":\"\",\"ProtoMajor\":0,\"ProtoMinor\":0,\"Header\":null,\"ContentLength\":0,\"TransferEncoding\":null,\"Host\":\"\",\"Form\":null,\"PostForm\":null,\"MultipartForm\":null,\"Trailer\":null,\"RemoteAddr\":\"\",\"RequestURI\":\"\",\"TLS\":null}")
+	c.Assert(len(DumpHttpRequest(req)) > 0, Equals, true)
 }


### PR DESCRIPTION
This change revamps logging in the following ways:
1. In the buffer (and any place really) where an error is returned,
   the log type is "Error" consistently, rather than info.

2. In ALL middlewares is a debug-level log that is emitted when a
   request is beginning to be served, and once when the ServeHTTP
   method exits (using defer). This allows, under debug conditions,
   a way to trace the flow of a request.

3. Added a discriminant prefix to each log entry so there's a clear understanding
    which subsystem or middleware the issue came from.

4. Finally, an important log entry which I feel was always missing,
   was an info-level entry that mentioned which specific backend
   server a particular request hit.