### PR TITLE
Logging revamp (#64)

### DIFF
--- a/cbreaker/cbreaker.go
+++ b/cbreaker/cbreaker.go
@@ -100,6 +100,11 @@ func New(next http.Handler, expression string, options ...CircuitBreakerOption) 
 }
 
 func (c *CircuitBreaker) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if log.GetLevel() >= log.DebugLevel {
+		logEntry := log.WithField("Request", utils.DumpHttpRequest(req))
+		logEntry.Debug("vulcand/oxy/circuitbreaker: begin ServeHttp on request")
+		defer logEntry.Debug("vulcand/oxy/circuitbreaker: competed ServeHttp on request")
+	}
 	if c.activateFallback(w, req) {
 		c.fallback.ServeHTTP(w, req)
 		return

--- a/cbreaker/fallback.go
+++ b/cbreaker/fallback.go
@@ -5,6 +5,9 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/vulcand/oxy/utils"
 )
 
 type Response struct {
@@ -25,6 +28,12 @@ func NewResponseFallback(r Response) (*ResponseFallback, error) {
 }
 
 func (f *ResponseFallback) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if log.GetLevel() >= log.DebugLevel {
+		logEntry := log.WithField("Request", utils.DumpHttpRequest(req))
+		logEntry.Debug("vulcand/oxy/fallback/response: begin ServeHttp on request")
+		defer logEntry.Debug("vulcand/oxy/fallback/response: competed ServeHttp on request")
+	}
+
 	if f.r.ContentType != "" {
 		w.Header().Set("Content-Type", f.r.ContentType)
 	}
@@ -50,6 +59,12 @@ func NewRedirectFallback(r Redirect) (*RedirectFallback, error) {
 }
 
 func (f *RedirectFallback) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if log.GetLevel() >= log.DebugLevel {
+		logEntry := log.WithField("Request", utils.DumpHttpRequest(req))
+		logEntry.Debug("vulcand/oxy/fallback/redirect: begin ServeHttp on request")
+		defer logEntry.Debug("vulcand/oxy/fallback/redirect: competed ServeHttp on request")
+	}
+
 	w.Header().Set("Location", f.u.String())
 	w.WriteHeader(http.StatusFound)
 	w.Write([]byte(http.StatusText(http.StatusFound)))

--- a/connlimit/connlimit.go
+++ b/connlimit/connlimit.go
@@ -107,6 +107,12 @@ type ConnErrHandler struct {
 }
 
 func (e *ConnErrHandler) ServeHTTP(w http.ResponseWriter, req *http.Request, err error) {
+	if log.GetLevel() >= log.DebugLevel {
+		logEntry := log.WithField("Request", utils.DumpHttpRequest(req))
+		logEntry.Debug("vulcand/oxy/connlimit: begin ServeHttp on request")
+		defer logEntry.Debug("vulcand/oxy/connlimit: competed ServeHttp on request")
+	}
+
 	if _, ok := err.(*MaxConnError); ok {
 		w.WriteHeader(429)
 		w.Write([]byte(err.Error()))

--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -188,6 +188,12 @@ func New(setters ...optSetter) (*Forwarder, error) {
 // ServeHTTP decides which forwarder to use based on the specified
 // request and delegates to the proper implementation
 func (f *Forwarder) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if log.GetLevel() >= log.DebugLevel {
+		logEntry := log.WithField("Request", utils.DumpHttpRequest(req))
+		logEntry.Debug("vulcand/oxy/forward: begin ServeHttp on request")
+		defer logEntry.Debug("vulcand/oxy/forward: competed ServeHttp on request")
+	}
+
 	if f.stateListener != nil {
 		f.stateListener(req.URL, StateConnected)
 		defer f.stateListener(req.URL, StateDisconnected)
@@ -203,24 +209,29 @@ func (f *Forwarder) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 // serveHTTP forwards HTTP traffic using the configured transport
 func (f *httpForwarder) serveHTTP(w http.ResponseWriter, req *http.Request, ctx *handlerContext) {
+	if log.GetLevel() >= log.DebugLevel {
+		logEntry := log.WithField("Request", utils.DumpHttpRequest(req))
+		logEntry.Debug("vulcand/oxy/forward/httpbuffer: begin ServeHttp on request")
+		defer logEntry.Debug("vulcand/oxy/forward/httpbuffer: competed ServeHttp on request")
+	}
 
 	start := time.Now().UTC()
 	response, err := f.roundTripper.RoundTrip(f.copyRequest(req, req.URL))
 	if err != nil {
-		log.Errorf("Error forwarding to %v, err: %v", req.URL, err)
+		log.Errorf("vulcand/oxy/forward/httpbuffer: Error forwarding to %v, err: %v", req.URL, err)
 		ctx.errHandler.ServeHTTP(w, req, err)
 		return
 	}
 
 	if req.TLS != nil {
-		log.Infof("Round trip: %v, code: %v, duration: %v tls:version: %x, tls:resume:%t, tls:csuite:%x, tls:server:%v",
+		log.Infof("vulcand/oxy/forward/httpbuffer: Round trip: %v, code: %v, duration: %v tls:version: %x, tls:resume:%t, tls:csuite:%x, tls:server:%v",
 			req.URL, response.StatusCode, time.Now().UTC().Sub(start),
 			req.TLS.Version,
 			req.TLS.DidResume,
 			req.TLS.CipherSuite,
 			req.TLS.ServerName)
 	} else {
-		log.Infof("Round trip: %v, code: %v, duration: %v",
+		log.Infof("vulcand/oxy/forward/httpbuffer: Round trip: %v, code: %v, duration: %v",
 			req.URL, response.StatusCode, time.Now().UTC().Sub(start))
 	}
 
@@ -231,7 +242,7 @@ func (f *httpForwarder) serveHTTP(w http.ResponseWriter, req *http.Request, ctx 
 	defer response.Body.Close()
 
 	if err != nil {
-		log.Errorf("Error copying upstream response Body: %v", err)
+		log.Errorf("vulcand/oxy/forward/httpbuffer: Error copying upstream response Body: %v", err)
 		ctx.errHandler.ServeHTTP(w, req, err)
 		return
 	}
@@ -275,6 +286,12 @@ func (f *httpForwarder) copyRequest(req *http.Request, u *url.URL) *http.Request
 
 // serveHTTP forwards websocket traffic
 func (f *websocketForwarder) serveHTTP(w http.ResponseWriter, req *http.Request, ctx *handlerContext) {
+	if log.GetLevel() >= log.DebugLevel {
+		logEntry := log.WithField("Request", utils.DumpHttpRequest(req))
+		logEntry.Debug("vulcand/oxy/forward/websocket: begin ServeHttp on request")
+		defer logEntry.Debug("vulcand/oxy/forward/websocket: competed ServeHttp on request")
+	}
+
 	outReq := f.copyRequest(req)
 	host := outReq.URL.Host
 
@@ -289,19 +306,19 @@ func (f *websocketForwarder) serveHTTP(w http.ResponseWriter, req *http.Request,
 
 	targetConn, err := f.dial("tcp", host)
 	if err != nil {
-		log.Errorf("Error dialing `%v`: %v", host, err)
+		log.Errorf("vulcand/oxy/forward/websocket: Error dialing `%v`: %v", host, err)
 		ctx.errHandler.ServeHTTP(w, req, err)
 		return
 	}
 	hijacker, ok := w.(http.Hijacker)
 	if !ok {
-		log.Errorf("Unable to hijack the connection: does not implement http.Hijacker. ResponseWriter implementation type: %v", reflect.TypeOf(w))
+		log.Errorf("vulcand/oxy/forward/websocket: Unable to hijack the connection: does not implement http.Hijacker. ResponseWriter implementation type: %v", reflect.TypeOf(w))
 		ctx.errHandler.ServeHTTP(w, req, err)
 		return
 	}
 	underlyingConn, _, err := hijacker.Hijack()
 	if err != nil {
-		log.Errorf("Unable to hijack the connection: %v", err)
+		log.Errorf("vulcand/oxy/forward/websocket: Unable to hijack the connection: %v", err)
 		ctx.errHandler.ServeHTTP(w, req, err)
 		return
 	}
@@ -309,11 +326,11 @@ func (f *websocketForwarder) serveHTTP(w http.ResponseWriter, req *http.Request,
 	defer underlyingConn.Close()
 	defer targetConn.Close()
 
-	log.Infof("Writing outgoing Websocket request to target connection: %+v", outReq)
+	log.Infof("vulcand/oxy/forward/websocket: Writing outgoing Websocket request to target connection: %+v", outReq)
 
 	// write the modified incoming request to the dialed connection
 	if err = outReq.Write(targetConn); err != nil {
-		log.Errorf("Unable to copy request to target: %v", err)
+		log.Errorf("vulcand/oxy/forward/websocket: Unable to copy request to target: %v", err)
 		ctx.errHandler.ServeHTTP(w, req, err)
 		return
 	}
@@ -366,6 +383,12 @@ func isWebsocketRequest(req *http.Request) bool {
 
 // serveHTTP forwards HTTP traffic using the configured transport
 func (f *httpStreamingForwarder) serveHTTP(w http.ResponseWriter, req *http.Request, ctx *handlerContext) {
+	if log.GetLevel() >= log.DebugLevel {
+		logEntry := log.WithField("Request", utils.DumpHttpRequest(req))
+		logEntry.Debug("vulcand/oxy/forward/httpstream: begin ServeHttp on request")
+		defer logEntry.Debug("vulcand/oxy/forward/httpstream: competed ServeHttp on request")
+	}
+
 	pw := &utils.ProxyWriter{
 		W: w,
 	}
@@ -390,14 +413,14 @@ func (f *httpStreamingForwarder) serveHTTP(w http.ResponseWriter, req *http.Requ
 	revproxy.ServeHTTP(pw, req)
 
 	if req.TLS != nil {
-		log.Infof("Round trip: %v, code: %v, Length: %v, duration: %v tls:version: %x, tls:resume:%t, tls:csuite:%x, tls:server:%v",
+		log.Infof("vulcand/oxy/forward/httpstream: Round trip: %v, code: %v, Length: %v, duration: %v tls:version: %x, tls:resume:%t, tls:csuite:%x, tls:server:%v",
 			req.URL, pw.Code, pw.Length, time.Now().UTC().Sub(start),
 			req.TLS.Version,
 			req.TLS.DidResume,
 			req.TLS.CipherSuite,
 			req.TLS.ServerName)
 	} else {
-		log.Infof("Round trip: %v, code: %v, Length: %v, duration: %v",
+		log.Infof("vulcand/oxy/forward/httpstream: Round trip: %v, code: %v, Length: %v, duration: %v",
 			req.URL, pw.Code, pw.Length, time.Now().UTC().Sub(start))
 	}
 }

--- a/roundrobin/rebalancer.go
+++ b/roundrobin/rebalancer.go
@@ -121,12 +121,23 @@ func (rb *Rebalancer) Servers() []*url.URL {
 }
 
 func (rb *Rebalancer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if log.GetLevel() >= log.DebugLevel {
+		logEntry := log.WithField("Request", utils.DumpHttpRequest(req))
+		logEntry.Debug("vulcand/oxy/roundrobin/rebalancer: begin ServeHttp on request")
+		defer logEntry.Debug("vulcand/oxy/roundrobin/rebalancer: competed ServeHttp on request")
+	}
+
 	pw := &utils.ProxyWriter{W: w}
 	start := rb.clock.UtcNow()
 	url, err := rb.next.NextServer()
 	if err != nil {
 		rb.errHandler.ServeHTTP(w, req, err)
 		return
+	}
+
+	if log.GetLevel() >= log.InfoLevel {
+		//log which backend URL we're sending this request to
+		log.WithFields(log.Fields{"Request": utils.DumpHttpRequest(req), "ForwardURL": url}).Info("vulcand/oxy/roundrobin/rebalancer: Forwarding this request to URL")
 	}
 
 	// make shallow copy of request before changing anything to avoid side effects

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -34,6 +34,7 @@ package stream
 import (
 	"net/http"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/vulcand/oxy/utils"
 )
 
@@ -81,5 +82,11 @@ func (s *Stream) Wrap(next http.Handler) error {
 }
 
 func (s *Stream) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if log.GetLevel() >= log.DebugLevel {
+		logEntry := log.WithField("Request", utils.DumpHttpRequest(req))
+		logEntry.Debug("vulcand/oxy/stream: begin ServeHttp on request")
+		defer logEntry.Debug("vulcand/oxy/stream: competed ServeHttp on request")
+	}
+
 	s.next.ServeHTTP(w, req)
 }

--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -15,6 +15,7 @@ import (
 
 	. "gopkg.in/check.v1"
 	"time"
+	log "github.com/Sirupsen/logrus"
 )
 
 func TestStream(t *testing.T) { TestingT(t) }
@@ -22,6 +23,14 @@ func TestStream(t *testing.T) { TestingT(t) }
 type STSuite struct{}
 
 var _ = Suite(&STSuite{})
+
+type noOpNextHttpHandler struct {}
+func (n noOpNextHttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {}
+
+type noOpIoWriter struct {}
+func (n noOpIoWriter) Write(bytes []byte) (int, error) {
+	return len(bytes), nil
+}
 
 func (s *STSuite) TestSimple(c *C) {
 	srv := testutils.NewHandler(func(w http.ResponseWriter, req *http.Request) {
@@ -312,4 +321,34 @@ func (s *STSuite) TestPreservesTLS(c *C) {
 	c.Assert(re.StatusCode, Equals, http.StatusOK)
 
 	c.Assert(t, NotNil)
+}
+
+
+
+func BenchmarkLoggingDebugLevel(b *testing.B) {
+	streamer, _:= New(noOpNextHttpHandler{})
+
+	log.SetLevel(log.DebugLevel)
+	log.SetOutput(&noOpIoWriter{}) //Make sure we don't emit a bunch of stuff on screen
+
+	for i := 0; i < b.N; i++ {
+		heavyServeHttpLoad(streamer)
+	}
+}
+
+func BenchmarkLoggingInfoLevel(b *testing.B) {
+	streamer, _ := New(noOpNextHttpHandler{})
+
+	log.SetLevel(log.InfoLevel)
+	log.SetOutput(&noOpIoWriter{}) //Make sure we don't emit a bunch of stuff on screen
+
+	for i := 0; i < b.N; i++ {
+		heavyServeHttpLoad(streamer)
+	}
+}
+
+func heavyServeHttpLoad(handler http.Handler) {
+	w := httptest.NewRecorder()
+	r := &http.Request{}
+	handler.ServeHTTP(w, r)
 }

--- a/utils/dumpreq.go
+++ b/utils/dumpreq.go
@@ -1,0 +1,60 @@
+package utils
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+)
+
+type SerializableHttpRequest struct {
+	Method           string
+	URL              *url.URL
+	Proto            string // "HTTP/1.0"
+	ProtoMajor       int    // 1
+	ProtoMinor       int    // 0
+	Header           http.Header
+	ContentLength    int64
+	TransferEncoding []string
+	Host             string
+	Form             url.Values
+	PostForm         url.Values
+	MultipartForm    *multipart.Form
+	Trailer          http.Header
+	RemoteAddr       string
+	RequestURI       string
+	TLS              *tls.ConnectionState
+}
+
+func Clone(r *http.Request) *SerializableHttpRequest {
+	if r == nil {
+		return nil
+	}
+
+	rc := new(SerializableHttpRequest)
+	rc.Method = r.Method
+	rc.URL = r.URL
+	rc.Proto = r.Proto
+	rc.ProtoMajor = r.ProtoMajor
+	rc.ProtoMinor = r.ProtoMinor
+	rc.Header = r.Header
+	rc.ContentLength = r.ContentLength
+	rc.Host = r.Host
+	rc.RemoteAddr = r.RemoteAddr
+	rc.RequestURI = r.RequestURI
+	return rc
+}
+
+func (s *SerializableHttpRequest) ToJson() string {
+	if jsonVal, err := json.Marshal(s); err != nil || jsonVal == nil {
+		return fmt.Sprintf("Error marshalling SerializableHttpRequest to json: %s", err.Error())
+	} else {
+		return string(jsonVal)
+	}
+}
+
+func DumpHttpRequest(req *http.Request) string {
+	return fmt.Sprintf("%v", Clone(req).ToJson())
+}

--- a/utils/dumpreq_test.go
+++ b/utils/dumpreq_test.go
@@ -1,0 +1,36 @@
+package utils
+
+import (
+	. "gopkg.in/check.v1"
+	"net/http"
+	"net/url"
+)
+
+type DumpHttpReqSuite struct {
+}
+
+var _ = Suite(&DumpHttpReqSuite{})
+
+type readCloserTestImpl struct {
+}
+
+func (r *readCloserTestImpl) Read(p []byte) (n int, err error) {
+	return 0, nil
+}
+
+func (r *readCloserTestImpl) Close() error {
+	return nil
+}
+
+//Just to make sure we don't panic, return err and not
+//username and pass and cover the function
+func (s *DumpHttpReqSuite) TestHttpReqToString(c *C) {
+	req := &http.Request{
+		URL:    &url.URL{Host: "localhost:2374", Path: "/unittest"},
+		Method: "DELETE",
+		Cancel: make(chan struct{}),
+		Body:   &readCloserTestImpl{},
+	}
+
+	c.Assert(len(DumpHttpRequest(req)) > 0, Equals, true)
+}


### PR DESCRIPTION
* Logging revamp

This change revamps logging in the following ways:
1. In the buffer (and any place really) where an error is returned,
   the log type is "Error" consistently, rather than info.

2. In ALL middlewares is a debug-level log that is emitted when a
   request is beginning to be served, and once when the ServeHTTP
   method exits (using defer). This allows, under debug conditions,
   a way to trace the flow of a request.

3. Finally, an important log entry which I feel was always missing,
   was an info-level entry that mentioned which specific backend
   server a particular request hit.

More logging improvements

More logging improvements

Http Streaming forwarder wasn't using ProxyWriter at all.

This was a fix made by Roy Sundahl. I'm merging it in here.

Attach standard logger as error logger for reverse proxy.

Revert "Attach standard logger as error logger for reverse proxy."

This reverts commit a39e0e7a1c9ecbd13af945a684a81fcaaa5a51f2.

Added an HTTP Request serializer for logging

Updated Serializer for http.Request objects

The challenge with logrus is it uses json.Marshall to serialize
object fields, but will log nothing if there's a marshalling error.

This prevented http.Request from getting serialized, and thus prevented
the entire entry from being logged.

By using httputil.DumpRequest, this change serializes
all http.Request objects (even if there's an error), and makes
sure a log entry is pushed.

Use JSON Serializer so the request is machine-parsable.

Revert "Use JSON Serializer so the request is machine-parsable."

This reverts commit a99a99299f2300dcaab1bb479c3f53cc1d76cc50.

Request serializer was a bad idea.

Attempting to serialize requests was a bad idea.

Serialize Http Request

Go fmt

* Fixed UT

Due to different golang versions, the fields in the struct
http.Request might be different across different runs of
the Unit Test. That means verifying that an http.Request correctly
serializes to a JSON String is not a fixed predictable operation
that is also portable across golang versions.

This change modifies the test to simply ensure length of the
generated string is more than zero.

Gated all expensive logs behind their log level.

This will ensure that if the log level is
what the log entry is, expensive processing
of serializing a full HTTP request isn't performed
per log entry.