### PR TITLE
Improve CopyHeaders performance

### DIFF
--- a/utils/netutils.go
+++ b/utils/netutils.go
@@ -3,12 +3,13 @@ package utils
 import (
 	"bufio"
 	"fmt"
-	log "github.com/Sirupsen/logrus"
 	"io"
 	"net"
 	"net/http"
 	"net/url"
 	"reflect"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 // ProxyWriter helps to capture response headers and status code
@@ -134,11 +135,9 @@ func CopyURL(i *url.URL) *url.URL {
 
 // CopyHeaders copies http headers from source to destination, it
 // does not overide, but adds multiple headers
-func CopyHeaders(dst, src http.Header) {
+func CopyHeaders(dst http.Header, src http.Header) {
 	for k, vv := range src {
-		for _, v := range vv {
-			dst.Add(k, v)
-		}
+		dst[k] = append(dst[k], vv...)
 	}
 }
 

--- a/utils/netutils_test.go
+++ b/utils/netutils_test.go
@@ -66,3 +66,29 @@ func (s *NetUtilsSuite) TestRemoveHeaders(c *C) {
 	c.Assert(source.Get("a"), Equals, "")
 	c.Assert(source.Get("c"), Equals, "d")
 }
+
+func BenchmarkCopyHeaders(b *testing.B) {
+	dstHeaders := make([]http.Header, 0, b.N)
+	sourceHeaders := make([]http.Header, 0, b.N)
+	for n := 0; n < b.N; n++ {
+		// example from a reverse proxy merging headers
+		d := http.Header{}
+		d.Add("Request-Id", "1bd36bcc-a0d1-4fc7-aedc-20bbdefa27c5")
+		dstHeaders = append(dstHeaders, d)
+
+		s := http.Header{}
+		s.Add("Content-Length", "374")
+		s.Add("Context-Type", "text/html; charset=utf-8")
+		s.Add("Etag", `"op14g6ae"`)
+		s.Add("Last-Modified", "Wed, 26 Apr 2017 18:24:06 GMT")
+		s.Add("Server", "Caddy")
+		s.Add("Date", "Fri, 28 Apr 2017 15:54:01 GMT")
+		s.Add("Accept-Ranges", "bytes")
+		sourceHeaders = append(sourceHeaders, s)
+	}
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		CopyHeaders(dstHeaders[n], sourceHeaders[n])
+	}
+}


### PR DESCRIPTION
I was doing some benchmarks of code using utils.CopyHeaders, and while there isn't much to improve here, by knowing that `http.Headers` is really just a `map[string][]string`, we can append to the string slice directly.  Doesn't save any allocs, but does save about 20% in CPU time in my tests:

```
benchmark                  old ns/op     new ns/op     delta
BenchmarkCopyHeaders-4     1273          1016          -20.19%
```
