### PR TITLE
Remove Hop-by-Hop headers when copying response. 

### DIFF
--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -13,11 +13,12 @@ import (
 	"time"
 
 	"crypto/tls"
-	log "github.com/Sirupsen/logrus"
-	"github.com/vulcand/oxy/utils"
 	"net"
 	"net/http/httputil"
 	"reflect"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/vulcand/oxy/utils"
 )
 
 // ReqRewriter can alter request headers and body
@@ -205,6 +206,16 @@ func (f *httpForwarder) serveBufferedHTTP(w http.ResponseWriter, req *http.Reque
 		log.Infof("vulcand/oxy/forward/httpbuffer: Round trip: %v, code: %v, duration: %v",
 			req.URL, response.StatusCode, time.Now().UTC().Sub(start))
 	}
+
+	// Connection: references headers that should be treated as hop by hop
+	if c := response.Header.Get("Connection"); c != "" {
+		for _, f := range strings.Split(c, ",") {
+			if f = strings.TrimSpace(f); f != "" {
+				response.Header.Del(f)
+			}
+		}
+	}
+	utils.RemoveHeaders(response.Header, HopHeaders...)
 
 	utils.CopyHeaders(w.Header(), response.Header)
 	w.WriteHeader(response.StatusCode)


### PR DESCRIPTION
Fixes #43

Currently have an internal fork of `forward` with a bunch of other changes, but this one is pretty obvious and can break things (see #43)...  

stdlib proxy also has similar code for removing hop by hop headers from responses:

https://github.com/golang/go/blob/go1.8.1/src/net/http/httputil/reverseproxy.go#L222-L224
