### PR TITLE
support for ipv6 with zone in request client ip address

### DIFF
--- a/forward/rewrite.go
+++ b/forward/rewrite.go
@@ -14,8 +14,14 @@ type HeaderRewriter struct {
 	Hostname           string
 }
 
+// clean up IP in case if it is ipv6 address and it has {zone} infromation in it, like "[fe80::d806:a55d:eb1b:49cc%vEthernet (vmxnet3 Ethernet Adapter - Virtual Switch)]:64692"
+func ipv6fix(clientIP string) string {
+	return strings.Split(clientIP, "%")[0]
+}
+
 func (rw *HeaderRewriter) Rewrite(req *http.Request) {
 	if clientIP, _, err := net.SplitHostPort(req.RemoteAddr); err == nil {
+		clientIP = ipv6fix(clientIP)
 		if rw.TrustForwardHeader {
 			if prior, ok := req.Header[XForwardedFor]; ok {
 				clientIP = strings.Join(prior, ", ") + ", " + clientIP

--- a/forward/rewrite_test.go
+++ b/forward/rewrite_test.go
@@ -1,0 +1,17 @@
+package forward
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIPv6Fix(t *testing.T) {
+	assert.Equal(t, "", ipv6fix(""))
+	assert.Equal(t, "127.0.0.1", ipv6fix("127.0.0.1"))
+	assert.Equal(t, "10.13.14.15", ipv6fix("10.13.14.15"))
+	assert.Equal(t, "fe80::d806:a55d:eb1b:49cc", ipv6fix(`fe80::d806:a55d:eb1b:49cc%vEthernet (vmxnet3 Ethernet Adapter - Virtual Switch)`))
+	assert.Equal(t, "fe80::1", ipv6fix(`fe80::1`))
+	assert.Equal(t, "2000::", ipv6fix(`2000::`))
+	assert.Equal(t, "2001:3452:4952:2837::", ipv6fix(`2001:3452:4952:2837::`))
+}


### PR DESCRIPTION
Proposal for https://github.com/vulcand/oxy/issues/71 fix:

In case if req.RemoteAddr contain IPv6 address in format with zone information, like:
`"RemoteAddr":"[fe80::d806:a55d:eb1b:49cc%vEthernet (vmxnet3 Ethernet Adapter - Virtual Switch)]:64692"`

net.SplitHostPort will do it best and split this address on host and port part, but according to RFC that defines IPv6 format for this header -  https://tools.ietf.org/html/rfc3986#section-3.2.2 - it tells - 

> This syntax does not support IPv6 scoped addressing zone identifiers.

so I suggest to filter out clientIP in case if it contains "%" in it's value.

