### PR TITLE
Simplify fwd.go, and enable WSS (Websockets over TLS)

### DIFF
--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -41,9 +41,12 @@ import (
 	"io/ioutil"
 	"net/http"
 
+	"bufio"
 	log "github.com/Sirupsen/logrus"
 	"github.com/mailgun/multibuf"
 	"github.com/vulcand/oxy/utils"
+	"net"
+	"reflect"
 )
 
 const (
@@ -231,8 +234,9 @@ func (s *Buffer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 		// We are mimicking http.ResponseWriter to replace writer with our special writer
 		b := &bufferWriter{
-			header: make(http.Header),
-			buffer: writer,
+			header:         make(http.Header),
+			buffer:         writer,
+			responseWriter: w,
 		}
 		defer b.Close()
 
@@ -295,9 +299,10 @@ func (s *Buffer) checkLimit(req *http.Request) error {
 }
 
 type bufferWriter struct {
-	header http.Header
-	code   int
-	buffer multibuf.WriterOnce
+	header         http.Header
+	code           int
+	buffer         multibuf.WriterOnce
+	responseWriter http.ResponseWriter
 }
 
 // RFC2616 #4.4
@@ -332,6 +337,24 @@ func (b *bufferWriter) Write(buf []byte) (int, error) {
 // WriteHeader sets rw.Code.
 func (b *bufferWriter) WriteHeader(code int) {
 	b.code = code
+}
+
+//CloseNotifier interface - this allows downstream connections to be terminated when the client terminates.
+func (b *bufferWriter) CloseNotify() <-chan bool {
+	if cn, ok := b.responseWriter.(http.CloseNotifier); ok {
+		return cn.CloseNotify()
+	}
+	log.Warningf("Upstream ResponseWriter of type %v does not implement http.CloseNotifier. Returning dummy channel.", reflect.TypeOf(b.responseWriter))
+	return make(<-chan bool)
+}
+
+//This allows connections to be hijacked for websockets for instance.
+func (b *bufferWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if hi, ok := b.responseWriter.(http.Hijacker); ok {
+		return hi.Hijack()
+	}
+	log.Warningf("Upstream ResponseWriter of type %v does not implement http.Hijacker. Returning dummy channel.", reflect.TypeOf(b.responseWriter))
+	return nil, nil, fmt.Errorf("The response writer that was wrapped in this proxy, does not implement http.Hijacker. It is of type: %v", reflect.TypeOf(b.responseWriter))
 }
 
 type SizeErrHandler struct {

--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -307,7 +307,7 @@ type bufferWriter struct {
 	code           int
 	buffer         multibuf.WriterOnce
 	responseWriter http.ResponseWriter
-	hijacked bool
+	hijacked       bool
 }
 
 // RFC2616 #4.4

--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -146,6 +146,10 @@ func New(setters ...optSetter) (*Forwarder, error) {
 		f.httpForwarder.rewriter = &HeaderRewriter{TrustForwardHeader: true, Hostname: h}
 	}
 
+	if f.httpForwarder.roundTripper == nil {
+		f.httpForwarder.roundTripper = http.DefaultTransport
+	}
+
 	if f.errHandler == nil {
 		f.errHandler = utils.DefaultHandler
 	}

--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -337,7 +337,9 @@ func (f *websocketForwarder) serveHTTP(w http.ResponseWriter, req *http.Request,
 	errc := make(chan error, 2)
 	replicate := func(dst io.Writer, src io.Reader, dstName string, srcName string) {
 		_, err := io.Copy(dst, src)
-		log.Errorf("vulcand/oxy/forward/websocket: Error when copying from %s to %s using io.Copy: %v", srcName, dstName, err)
+		if err != nil {
+			log.Errorf("vulcand/oxy/forward/websocket: Error when copying from %s to %s using io.Copy: %v", srcName, dstName, err)
+		}
 		errc <- err
 	}
 	go replicate(targetConn, underlyingConn, "backend", "client")

--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -12,12 +12,12 @@ import (
 	"strings"
 	"time"
 
-	"crypto/tls"
 	log "github.com/Sirupsen/logrus"
 	"github.com/vulcand/oxy/utils"
-	"net"
 	"net/http/httputil"
 	"reflect"
+	"net"
+	"crypto/tls"
 )
 
 // ReqRewriter can alter request headers and body
@@ -44,6 +44,7 @@ func RoundTripper(r http.RoundTripper) optSetter {
 		return nil
 	}
 }
+
 
 // Rewriter defines a request rewriter for the HTTP forwarder
 func Rewriter(r ReqRewriter) optSetter {
@@ -341,7 +342,8 @@ func (f *websocketForwarder) serveHTTP(w http.ResponseWriter, req *http.Request,
 	var targetConn net.Conn
 	var err error
 
-	if f.tlsClientConfig != nil {
+
+	if outReq.URL.Scheme == "wss" && f.tlsClientConfig != nil {
 		targetConn, err = tls.Dial("tcp", host, f.tlsClientConfig)
 	} else {
 		targetConn, err = net.Dial("tcp", host)
@@ -438,6 +440,7 @@ func isWebsocketRequest(req *http.Request) bool {
 	}
 	return containsHeader(Connection, "upgrade") && containsHeader(Upgrade, "websocket")
 }
+
 
 // copyRequest makes a copy of the specified request to be sent using the configured
 // transport

--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -12,12 +12,12 @@ import (
 	"strings"
 	"time"
 
+	"crypto/tls"
 	log "github.com/Sirupsen/logrus"
 	"github.com/vulcand/oxy/utils"
+	"net"
 	"net/http/httputil"
 	"reflect"
-	"net"
-	"crypto/tls"
 )
 
 // ReqRewriter can alter request headers and body
@@ -44,7 +44,6 @@ func RoundTripper(r http.RoundTripper) optSetter {
 		return nil
 	}
 }
-
 
 // Rewriter defines a request rewriter for the HTTP forwarder
 func Rewriter(r ReqRewriter) optSetter {
@@ -106,7 +105,6 @@ func StreamRoundTripper(r http.RoundTripper) optSetter {
 	}
 }
 
-
 // PassHostHeader specifies if a client's Host header field should
 // be delegated
 func StreamPassHostHeader(b bool) optSetter {
@@ -166,7 +164,7 @@ type httpForwarder struct {
 // HTTP traffic but doesn't wait for a complete
 // response before it begins writing bytes upstream
 type httpStreamingForwarder struct {
-	roundTripper http.RoundTripper
+	roundTripper  http.RoundTripper
 	rewriter      ReqRewriter
 	passHost      bool
 	flushInterval time.Duration
@@ -427,14 +425,14 @@ func (f *websocketForwarder) copyRequest(req *http.Request) (outReq *http.Reques
 	outReq.URL.Path = req.RequestURI
 
 	/*
-	// Do not pass client Host header unless optsetter PassHostHeader is set.
-	if !f.passHost {
-		outReq.Host = req.Host
-	}
+		// Do not pass client Host header unless optsetter PassHostHeader is set.
+		if !f.passHost {
+			outReq.Host = req.Host
+		}
 
-	if f.rewriter != nil {
-		f.rewriter.Rewrite(outReq)
-	}
+		if f.rewriter != nil {
+			f.rewriter.Rewrite(outReq)
+		}
 	*/
 
 	return outReq
@@ -454,7 +452,6 @@ func isWebsocketRequest(req *http.Request) bool {
 	}
 	return containsHeader(Connection, "upgrade") && containsHeader(Upgrade, "websocket")
 }
-
 
 // copyRequest makes a copy of the specified request to be sent using the configured
 // transport

--- a/forward/fwd_test.go
+++ b/forward/fwd_test.go
@@ -287,7 +287,7 @@ func (s *FwdSuite) TestDetectsWebsocketRequest(c *C) {
 		conn.Close()
 	}))
 	srv := testutils.NewHandler(func(w http.ResponseWriter, req *http.Request) {
-		websocketRequest := isWebsocketRequest(req)
+		websocketRequest := IsWebsocketRequest(req)
 		c.Assert(websocketRequest, Equals, true)
 		mux.ServeHTTP(w, req)
 	})

--- a/roundrobin/RequestRewriteListener.go
+++ b/roundrobin/RequestRewriteListener.go
@@ -1,0 +1,5 @@
+package roundrobin
+
+import "net/http"
+
+type RequestRewriteListener func(oldReq *http.Request, newReq *http.Request)

--- a/roundrobin/rebalancer.go
+++ b/roundrobin/rebalancer.go
@@ -47,6 +47,8 @@ type Rebalancer struct {
 
 	// creates new meters
 	newMeter NewMeterFn
+
+	requestRewriteListener RequestRewriteListener
 }
 
 func RebalancerClock(clock timetools.TimeProvider) RebalancerOption {
@@ -74,6 +76,14 @@ func RebalancerMeter(newMeter NewMeterFn) RebalancerOption {
 func RebalancerErrorHandler(h utils.ErrorHandler) RebalancerOption {
 	return func(r *Rebalancer) error {
 		r.errHandler = h
+		return nil
+	}
+}
+
+// RebalancerErrorHandler is a functional argument that sets error handler of the server
+func RebalancerRequestRewriteListener(rrl RequestRewriteListener) RebalancerOption {
+	return func(r *Rebalancer) error {
+		r.requestRewriteListener = rrl
 		return nil
 	}
 }
@@ -135,14 +145,20 @@ func (rb *Rebalancer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if log.GetLevel() >= log.InfoLevel {
+	if log.GetLevel() >= log.DebugLevel {
 		//log which backend URL we're sending this request to
-		log.WithFields(log.Fields{"Request": utils.DumpHttpRequest(req), "ForwardURL": url}).Info("vulcand/oxy/roundrobin/rebalancer: Forwarding this request to URL")
+		log.WithFields(log.Fields{"Request": utils.DumpHttpRequest(req), "ForwardURL": url}).Debugf("vulcand/oxy/roundrobin/rebalancer: Forwarding this request to URL")
 	}
 
 	// make shallow copy of request before changing anything to avoid side effects
 	newReq := *req
 	newReq.URL = url
+
+	//Emit event to a listener if one exists
+	if rb.requestRewriteListener != nil {
+		rb.requestRewriteListener(req, &newReq)
+	}
+
 	rb.next.Next().ServeHTTP(pw, &newReq)
 
 	rb.recordMetrics(url, pw.Code, rb.clock.UtcNow().Sub(start))

--- a/roundrobin/rebalancer_test.go
+++ b/roundrobin/rebalancer_test.go
@@ -320,6 +320,25 @@ func (s *RBSuite) TestRebalancerLive(c *C) {
 	c.Assert(rb.servers[2].curWeight, Equals, 1)
 }
 
+func (s *RBSuite) TestRequestRewriteListener(c *C) {
+	a, b := testutils.NewResponder("a"), testutils.NewResponder("b")
+	defer a.Close()
+	defer b.Close()
+
+	fwd, err := forward.New()
+	c.Assert(err, IsNil)
+
+	lb, err := New(fwd)
+	c.Assert(err, IsNil)
+
+	rb, err := NewRebalancer(lb,
+		RebalancerRequestRewriteListener(func(oldReq *http.Request, newReq *http.Request) {
+		}))
+	c.Assert(err, IsNil)
+
+	c.Assert(rb.requestRewriteListener, NotNil)
+}
+
 type testMeter struct {
 	rating   float64
 	notReady bool

--- a/roundrobin/rr_test.go
+++ b/roundrobin/rr_test.go
@@ -205,6 +205,24 @@ func (s *RRSuite) TestWeighted(c *C) {
 	c.Assert(ok, Equals, false)
 }
 
+func (s *RRSuite) TestRequestRewriteListener(c *C) {
+	a := testutils.NewResponder("a")
+	defer a.Close()
+
+	b := testutils.NewResponder("b")
+	defer b.Close()
+
+	fwd, err := forward.New()
+	c.Assert(err, IsNil)
+
+	lb, err := New(fwd,
+		RoundRobinRequestRewriteListener(func(oldReq *http.Request, newReq *http.Request) {
+		}))
+	c.Assert(err, IsNil)
+
+	c.Assert(lb.requestRewriteListener, NotNil)
+}
+
 func seq(c *C, url string, repeat int) []string {
 	out := []string{}
 	for i := 0; i < repeat; i++ {

--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/vulcand/oxy/forward"
 	"github.com/vulcand/oxy/testutils"
 
+	log "github.com/Sirupsen/logrus"
 	. "gopkg.in/check.v1"
 	"time"
-	log "github.com/Sirupsen/logrus"
 )
 
 func TestStream(t *testing.T) { TestingT(t) }
@@ -24,10 +24,12 @@ type STSuite struct{}
 
 var _ = Suite(&STSuite{})
 
-type noOpNextHttpHandler struct {}
+type noOpNextHttpHandler struct{}
+
 func (n noOpNextHttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {}
 
-type noOpIoWriter struct {}
+type noOpIoWriter struct{}
+
 func (n noOpIoWriter) Write(bytes []byte) (int, error) {
 	return len(bytes), nil
 }
@@ -323,10 +325,8 @@ func (s *STSuite) TestPreservesTLS(c *C) {
 	c.Assert(t, NotNil)
 }
 
-
-
 func BenchmarkLoggingDebugLevel(b *testing.B) {
-	streamer, _:= New(noOpNextHttpHandler{})
+	streamer, _ := New(noOpNextHttpHandler{})
 
 	log.SetLevel(log.DebugLevel)
 	log.SetOutput(&noOpIoWriter{}) //Make sure we don't emit a bunch of stuff on screen


### PR DESCRIPTION
This is a significant change with the following goals:
1. Improve websockets implementation with WSS support (there was no way to dial a TLS Websocket port in the previous iteration.)
2. Improve Streaming Forwarder to be on feature-parity with buffered forwarder.

Consolidation of Forwarders:
After all the changes (described below), it became apparent that the forwarders only differed in
a few small things:
1. One or two specific fields.
2. The copyRequest function (which is different for http vs ws)
3. The ServeHTTP method.

I consolidated all three of them together so the ServeHttp methods of each type benefits from settings configured for httpForwarder. It also avoids a lot of code noise, and redundant functions.

Specific changes of note that led to this:
1. Remove the "Dialer" for WebSocket forwarder since it didn't make immediate sense. If this is a problem, I'm happy to change that. I want to make Dialer an interface that'll support TLS config.

2. Added a Rewriter/PassHost fields to stream. This is important because even those connections ultimately might want Forward headers, etc. 

3. This field is added to, but not used in Websockets because I need to debug more. It is used in stream where it works.

4. Stream uses the same roundtripper for ReverseProxying that buffered forwarder was using. This means it inherits TLS config settings like InsecureSkipVerify.

5. Websocket logs are more descriptive - especially when something fails.

6. For the BufferedWriter Response Proxy, implemented interfaces "http.Hijacker" which allows a Websockets upgrade, and more importantly, http.CloseNotifier which allows Serve/ServeTLS to terminate the downstream connection if/when the client disconnects abruptly. This might be a performance improvement when a client creates a lot of connections but disconnects rapidly.