### PR TITLE
Fixes in handling websockets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,6 @@ _testmain.go
 *.exe
 *.test
 *.prof
+.idea/
 
 flymake_*

--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -358,10 +358,6 @@ func (f *httpForwarder) copyWebSocketRequest(req *http.Request) (outReq *http.Re
 		outReq.Host = req.Host
 	}
 
-	outReq.Proto = "HTTP/1.1"
-	outReq.ProtoMajor = 1
-	outReq.ProtoMinor = 1
-
 	// Overwrite close flag so we can keep persistent connection for the backend servers
 	outReq.Close = false
 

--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -327,8 +327,10 @@ func (f *httpForwarder) serveWebSocket(w http.ResponseWriter, req *http.Request,
 	}
 	go replicate(targetConn, underlyingConn, "backend", "client")
 	go replicate(underlyingConn, targetConn, "client", "backend")
-	err = <-errc
-	log.Infof("vulcand/oxy/forward/websocket: websocket proxying complete: %v", err)
+	err = <-errc // One goroutine complete
+	log.Infof("vulcand/oxy/forward/websocket: > websocket proxying complete: %v", err)
+	err = <-errc // Both goroutines complete
+	log.Infof("vulcand/oxy/forward/websocket: < websocket proxying complete: %v", err)
 }
 
 // copyRequest makes a copy of the specified request.
@@ -349,12 +351,22 @@ func (f *httpForwarder) copyWebSocketRequest(req *http.Request) (outReq *http.Re
 	}
 
 	outReq.URL.Host = req.URL.Host
-	outReq.URL.Path = req.RequestURI
+	outReq.URL.Opaque = req.RequestURI
 
 	// Do not pass client Host header unless optsetter PassHostHeader is set.
 	if !f.passHost {
 		outReq.Host = req.Host
 	}
+
+	outReq.Proto = "HTTP/1.1"
+	outReq.ProtoMajor = 1
+	outReq.ProtoMinor = 1
+
+	// Overwrite close flag so we can keep persistent connection for the backend servers
+	outReq.Close = false
+
+	outReq.Header = make(http.Header)
+	utils.CopyHeaders(outReq.Header, req.Header)
 
 	if f.rewriter != nil {
 		f.rewriter.Rewrite(outReq)

--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -328,9 +328,9 @@ func (f *httpForwarder) serveWebSocket(w http.ResponseWriter, req *http.Request,
 	go replicate(targetConn, underlyingConn, "backend", "client")
 	go replicate(underlyingConn, targetConn, "client", "backend")
 	err = <-errc // One goroutine complete
-	log.Infof("vulcand/oxy/forward/websocket: > websocket proxying complete: %v", err)
+	log.Infof("vulcand/oxy/forward/websocket: first proxying connection closed: %v", err)
 	err = <-errc // Both goroutines complete
-	log.Infof("vulcand/oxy/forward/websocket: < websocket proxying complete: %v", err)
+	log.Infof("vulcand/oxy/forward/websocket: second proxying connection closed: %v", err)
 }
 
 // copyRequest makes a copy of the specified request.


### PR DESCRIPTION
This PR fixes the following problems:

- premature closing of websocket streams
- missing code to copy headers to the target request (need at least websocket upgrade headers for the upgrade protocol to work)
- the way the request URL path was copied was producing an Url with the query separator Url encoded, which some servers won't tolerate (I ran into issues on Wildfly)


Signed-off-by: Mariusz Borsa mborsa@polyverse.io