### PR TITLE
Allow disabling logging

### DIFF
--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -42,8 +42,8 @@ import (
 	"net/http"
 
 	"bufio"
-	log "github.com/sirupsen/logrus"
 	"github.com/mailgun/multibuf"
+	"github.com/vulcand/oxy/log"
 	"github.com/vulcand/oxy/utils"
 	"net"
 	"reflect"

--- a/cbreaker/cbreaker.go
+++ b/cbreaker/cbreaker.go
@@ -31,9 +31,8 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/sirupsen/logrus"
-
 	"github.com/mailgun/timetools"
+	"github.com/vulcand/oxy/log"
 	"github.com/vulcand/oxy/memmetrics"
 	"github.com/vulcand/oxy/utils"
 )

--- a/cbreaker/effect.go
+++ b/cbreaker/effect.go
@@ -9,7 +9,7 @@ import (
 	"net/url"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/vulcand/oxy/log"
 	"github.com/vulcand/oxy/utils"
 )
 

--- a/cbreaker/fallback.go
+++ b/cbreaker/fallback.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"strconv"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/vulcand/oxy/log"
 	"github.com/vulcand/oxy/utils"
 )
 

--- a/cbreaker/predicates.go
+++ b/cbreaker/predicates.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/vulcand/oxy/log"
 	"github.com/vulcand/predicate"
 )
 

--- a/cbreaker/ratio.go
+++ b/cbreaker/ratio.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/mailgun/timetools"
+	"github.com/vulcand/oxy/log"
 )
 
 // ratioController allows passing portions traffic back to the endpoints,

--- a/connlimit/connlimit.go
+++ b/connlimit/connlimit.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"sync"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/vulcand/oxy/log"
 	"github.com/vulcand/oxy/utils"
 )
 

--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"crypto/tls"
-	log "github.com/sirupsen/logrus"
+	"github.com/vulcand/oxy/log"
 	"github.com/vulcand/oxy/utils"
 	"net"
 	"net/http/httputil"

--- a/log/log.go
+++ b/log/log.go
@@ -1,0 +1,47 @@
+package log
+
+import (
+	"io/ioutil"
+
+	"github.com/Sirupsen/logrus"
+)
+
+var log *logrus.Logger
+
+const DebugLevel = logrus.DebugLevel
+
+func Debugf(format string, args ...interface{}) {
+	log.Debugf(format, args...)
+}
+
+func Infof(format string, args ...interface{}) {
+	log.Infof(format, args...)
+}
+
+func Warningf(format string, args ...interface{}) {
+	log.Warningf(format, args...)
+}
+
+func Errorf(format string, args ...interface{}) {
+	log.Errorf(format, args...)
+}
+
+func WithField(key string, value interface{}) *logrus.Entry {
+	return log.WithField(key, value)
+}
+
+func WithFields(fields logrus.Fields) *logrus.Entry {
+	return log.WithFields(fields)
+}
+
+func GetLevel() logrus.Level {
+	return log.Level
+}
+
+func init() {
+	log = logrus.New()
+}
+
+func Disable() {
+	log.Out = ioutil.Discard
+}

--- a/ratelimit/tokenlimiter.go
+++ b/ratelimit/tokenlimiter.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/mailgun/timetools"
 	"github.com/mailgun/ttlmap"
+	"github.com/vulcand/oxy/log"
 	"github.com/vulcand/oxy/utils"
 )
 

--- a/roundrobin/rebalancer.go
+++ b/roundrobin/rebalancer.go
@@ -147,7 +147,6 @@ func (rb *Rebalancer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	if log.GetLevel() >= log.DebugLevel {
 		//log which backend URL we're sending this request to
-		//log.WithFields(log.Fields{"Request": utils.DumpHttpRequest(req), "ForwardURL": url}).Debugf("vulcand/oxy/roundrobin/rebalancer: Forwarding this request to URL")
 		log.WithField("Request", utils.DumpHttpRequest(req)).WithField("ForwardURL", url).Debugf("vulcand/oxy/roundrobin/rebalancer: Forwarding this request to URL")
 	}
 

--- a/roundrobin/rebalancer.go
+++ b/roundrobin/rebalancer.go
@@ -7,8 +7,8 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/mailgun/timetools"
+	"github.com/vulcand/oxy/log"
 	"github.com/vulcand/oxy/memmetrics"
 	"github.com/vulcand/oxy/utils"
 )
@@ -147,7 +147,8 @@ func (rb *Rebalancer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	if log.GetLevel() >= log.DebugLevel {
 		//log which backend URL we're sending this request to
-		log.WithFields(log.Fields{"Request": utils.DumpHttpRequest(req), "ForwardURL": url}).Debugf("vulcand/oxy/roundrobin/rebalancer: Forwarding this request to URL")
+		//log.WithFields(log.Fields{"Request": utils.DumpHttpRequest(req), "ForwardURL": url}).Debugf("vulcand/oxy/roundrobin/rebalancer: Forwarding this request to URL")
+		log.WithField("Request", utils.DumpHttpRequest(req)).WithField("ForwardURL", url).Debugf("vulcand/oxy/roundrobin/rebalancer: Forwarding this request to URL")
 	}
 
 	// make shallow copy of request before changing anything to avoid side effects

--- a/roundrobin/rr.go
+++ b/roundrobin/rr.go
@@ -86,7 +86,6 @@ func (r *RoundRobin) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	if log.GetLevel() >= log.DebugLevel {
 		//log which backend URL we're sending this request to
-		//log.WithFields(log.Fields{"Request": utils.DumpHttpRequest(req), "ForwardURL": url}).Debugf("vulcand/oxy/roundrobin/rr: Forwarding this request to URL")
 		log.WithField("Request", utils.DumpHttpRequest(req)).WithField("ForwardURL", url).Debugf("vulcand/oxy/roundrobin/rr: Forwarding this request to URL")
 	}
 

--- a/roundrobin/rr.go
+++ b/roundrobin/rr.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"sync"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/vulcand/oxy/log"
 	"github.com/vulcand/oxy/utils"
 )
 
@@ -86,7 +86,8 @@ func (r *RoundRobin) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	if log.GetLevel() >= log.DebugLevel {
 		//log which backend URL we're sending this request to
-		log.WithFields(log.Fields{"Request": utils.DumpHttpRequest(req), "ForwardURL": url}).Debugf("vulcand/oxy/roundrobin/rr: Forwarding this request to URL")
+		//log.WithFields(log.Fields{"Request": utils.DumpHttpRequest(req), "ForwardURL": url}).Debugf("vulcand/oxy/roundrobin/rr: Forwarding this request to URL")
+		log.WithField("Request", utils.DumpHttpRequest(req)).WithField("ForwardURL", url).Debugf("vulcand/oxy/roundrobin/rr: Forwarding this request to URL")
 	}
 
 	// make shallow copy of request before chaning anything to avoid side effects

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -34,7 +34,7 @@ package stream
 import (
 	"net/http"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/vulcand/oxy/log"
 	"github.com/vulcand/oxy/utils"
 )
 

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"time"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/vulcand/oxy/log"
 	"github.com/vulcand/oxy/utils"
 )
 

--- a/utils/netutils.go
+++ b/utils/netutils.go
@@ -9,7 +9,7 @@ import (
 	"net/url"
 	"reflect"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/vulcand/oxy/log"
 )
 
 // ProxyWriter helps to capture response headers and status code


### PR DESCRIPTION
There is now a `log` package, which wraps the `logrus` methods used in
oxy.  In addition to the methods that are used, there is a `.Disable`
method that disables logging by sending them to `/dev/null`.

Fixes #83.