### PR TITLE
Don't duplicate query parameters when streaming.

### DIFF
--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -398,7 +398,6 @@ func (f *httpForwarder) serveStreamingHTTP(w http.ResponseWriter, inReq *http.Re
 	urlcpy.Host = outReq.URL.Host
 
 	outReq.URL.Path = reqUrl.Path
-	outReq.URL.RawQuery = reqUrl.RawQuery
 
 	revproxy := httputil.NewSingleHostReverseProxy(urlcpy)
 	revproxy.Transport = f.roundTripper


### PR DESCRIPTION
The ReverseProxy appears to repeat url parameters passed in via RawQuery
to the downstream host. I placed a small server behind a streaming
proxy, dumped the request with `httputil.DumpRequest` and saw duplicated query
parameters reflected in the RequestURI.

Laying this out there for now - this PR is quite bare and the behavior at least merits a test case.  It looks like a similar fix was put in place for the `serveBufferedHTTP` handler, which makes me suspect that either the streaming handler hasn't gotten the same love as the buffered handler  (and is therefore discouraged), or that I'm doing something else wrong. 

You can see the underlying NewSingleHostReverseProxy code does attempt to merge query parameters: https://golang.org/src/net/http/httputil/reverseproxy.go?s=2588:2649#L95

`curl -v -N "localhost:8080/resources?kind=Process"`

Before:
```
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8080 (#0)
> GET /resources?kind=Process&kind=Process HTTP/1.1
> Host: localhost:8085
> User-Agent: curl/7.54.0
> Accept: */*
>
```

After:
```
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8080 (#0)
> GET /resources?kind=Process HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.54.0
> Accept: */*
>
```

Additionally, the [parsing of reqUrl](https://github.com/vulcand/oxy/blob/master/forward/fwd.go#L237) seems unnecessary as well. It looks like some refactoring might have made this redundant as copyRequest appears to account for these "gotchas".