### PR TITLE
Bring back the context logger

### DIFF
--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -81,7 +81,7 @@ func Stream(stream bool) optSetter {
 
 // Logger defines the logger the forwarder will use.
 //
-// It defaults to logrus.New(), the default logger created by logrus.
+// It defaults to logrus.StandardLogger(), the global logger used by logrus.
 func Logger(l *log.Logger) optSetter {
 	return func(f *Forwarder) error {
 		f.log = l
@@ -141,7 +141,7 @@ type UrlForwardingStateListener func(*url.URL, int)
 // New creates an instance of Forwarder based on the provided list of configuration options
 func New(setters ...optSetter) (*Forwarder, error) {
 	f := &Forwarder{
-		httpForwarder:  &httpForwarder{flushInterval: time.Duration(100) * time.Millisecond, log: log.New()},
+		httpForwarder:  &httpForwarder{flushInterval: time.Duration(100) * time.Millisecond, log: log.StandardLogger()},
 		handlerContext: &handlerContext{},
 	}
 	for _, s := range setters {

--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -71,8 +71,7 @@ func ErrorHandler(h utils.ErrorHandler) optSetter {
 	}
 }
 
-// Logger specifies the logger to use.
-// Forwarder will default to oxyutils.NullLogger if no logger has been specified
+// Stream specifies if HTTP responses should be streamed.
 func Stream(stream bool) optSetter {
 	return func(f *Forwarder) error {
 		f.stream = stream

--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -79,6 +79,9 @@ func Stream(stream bool) optSetter {
 	}
 }
 
+// Logger defines the logger the forwarder will use.
+//
+// It defaults to logrus.New(), the default logger created by logrus.
 func Logger(l *log.Logger) optSetter {
 	return func(f *Forwarder) error {
 		f.log = l


### PR DESCRIPTION
As discussed in #85, this brings back the "context logger" that used to be part of oxy.

This allows passing a custom logger to oxy that can be changed as appropriate for applications.

This starts with the `forward` package.  Let's review that first, and when we're happy with the design I'll add similar changes for the other packages to this PR.

Usage is currently as follows:

```go
package main

import (
  "fmt"

  "github.com/vulcand/oxy/forward"
  "github.com/sirupsen/logrus"
)

func main() {
  logger := logrus.New()
  logger.SetLevel(logrus.WarnLevel)
  fwd, _ := forward.New(forward.Logger(logger))
  fmt.Println(fwd)
}
```