### PR TITLE
Buffer ReverseProxy use http.ReverseProxy

### DIFF
--- a/forward/fwd_websocket_test.go
+++ b/forward/fwd_websocket_test.go
@@ -274,7 +274,7 @@ func (s *FwdSuite) TestWebSocketUpgradeFailed(c *C) {
 	defer proxy.Close()
 
 	proxyAddr := proxy.Listener.Addr().String()
-	conn, err := net.DialTimeout("tcp", proxyAddr, dialTimeout)
+	conn, err := net.DialTimeout("tcp", proxyAddr, time.Second*5)
 
 	c.Assert(err, IsNil)
 	defer conn.Close()

--- a/forward/headers.go
+++ b/forward/headers.go
@@ -4,7 +4,9 @@ const (
 	XForwardedProto        = "X-Forwarded-Proto"
 	XForwardedFor          = "X-Forwarded-For"
 	XForwardedHost         = "X-Forwarded-Host"
+	XForwardedPort         = "X-Forwarded-Port"
 	XForwardedServer       = "X-Forwarded-Server"
+	XRealIp                = "X-Real-Ip"
 	Connection             = "Connection"
 	KeepAlive              = "Keep-Alive"
 	ProxyAuthenticate      = "Proxy-Authenticate"
@@ -47,4 +49,13 @@ var WebsocketUpgradeHeaders = []string{
 	Upgrade,
 	Connection,
 	SecWebsocketAccept,
+}
+
+var XHeaders = []string{
+	XForwardedProto,
+	XForwardedFor,
+	XForwardedHost,
+	XForwardedPort,
+	XForwardedServer,
+	XRealIp,
 }

--- a/forward/rewrite.go
+++ b/forward/rewrite.go
@@ -20,22 +20,33 @@ func ipv6fix(clientIP string) string {
 }
 
 func (rw *HeaderRewriter) Rewrite(req *http.Request) {
-	if clientIP, _, err := net.SplitHostPort(req.RemoteAddr); err == nil {
-		clientIP = ipv6fix(clientIP)
-		if rw.TrustForwardHeader {
-			if prior, ok := req.Header[XForwardedFor]; ok {
-				clientIP = strings.Join(prior, ", ") + ", " + clientIP
-			}
-		}
-		req.Header.Set(XForwardedFor, clientIP)
+	if !rw.TrustForwardHeader {
+		utils.RemoveHeaders(req.Header, XHeaders...)
 	}
 
-	if xfp := req.Header.Get(XForwardedProto); xfp != "" && rw.TrustForwardHeader {
-		req.Header.Set(XForwardedProto, xfp)
-	} else if req.TLS != nil {
-		req.Header.Set(XForwardedProto, "https")
-	} else {
-		req.Header.Set(XForwardedProto, "http")
+	if clientIP, _, err := net.SplitHostPort(req.RemoteAddr); err == nil {
+		clientIP = ipv6fix(clientIP)
+		// If not websocket, done in http.ReverseProxy
+		if IsWebsocketRequest(req) {
+			if prior, ok := req.Header[XForwardedFor]; ok {
+				req.Header.Set(XForwardedFor, strings.Join(prior, ", ")+", "+clientIP)
+			} else {
+				req.Header.Set(XForwardedFor, clientIP)
+			}
+		}
+
+		if req.Header.Get(XRealIp) == "" {
+			req.Header.Set(XRealIp, clientIP)
+		}
+	}
+
+	xfProto := req.Header.Get(XForwardedProto)
+	if xfProto == "" {
+		if req.TLS != nil {
+			req.Header.Set(XForwardedProto, "https")
+		} else {
+			req.Header.Set(XForwardedProto, "http")
+		}
 	}
 
 	if IsWebsocketRequest(req) {
@@ -46,9 +57,11 @@ func (rw *HeaderRewriter) Rewrite(req *http.Request) {
 		}
 	}
 
-	if xfh := req.Header.Get(XForwardedHost); xfh != "" && rw.TrustForwardHeader {
-		req.Header.Set(XForwardedHost, xfh)
-	} else if req.Host != "" {
+	if xfp := req.Header.Get(XForwardedPort); xfp == "" {
+		req.Header.Set(XForwardedPort, forwardedPort(req))
+	}
+
+	if xfHost := req.Header.Get(XForwardedHost); xfHost == "" && req.Host != "" {
 		req.Header.Set(XForwardedHost, req.Host)
 	}
 
@@ -61,4 +74,20 @@ func (rw *HeaderRewriter) Rewrite(req *http.Request) {
 		// connection, regardless of what the client sent to us.
 		utils.RemoveHeaders(req.Header, HopHeaders...)
 	}
+}
+
+func forwardedPort(req *http.Request) string {
+	if req == nil {
+		return ""
+	}
+
+	if _, port, err := net.SplitHostPort(req.Host); err == nil && port != "" {
+		return port
+	}
+
+	if req.TLS != nil {
+		return "443"
+	}
+
+	return "80"
 }

--- a/forward/rewrite.go
+++ b/forward/rewrite.go
@@ -57,7 +57,7 @@ func (rw *HeaderRewriter) Rewrite(req *http.Request) {
 		}
 	}
 
-	if xfp := req.Header.Get(XForwardedPort); xfp == "" {
+	if xfPort := req.Header.Get(XForwardedPort); xfPort == "" {
 		req.Header.Set(XForwardedPort, forwardedPort(req))
 	}
 


### PR DESCRIPTION
This PR merge serveBufferHTTP and serveStreamHTTP to both use the http.ReverseProxy (as http.ReverseProxy without flushInterval works in "buffer" mode)
 We fix XForwarded too because some parts are already in http.ReverseProxy

http.ReverseProxy don't have `ErrorHandling`, that's why I have wrote a [PR on go](https://go-review.googlesource.com/c/go/+/77410).
In the meantime, I have proxied the RoundTripper in order to catch the errors.
With this, there is a little breaking change, in the ErrorHandler.serveHTTP, you can not Hijack/Flush anymore.