### PR TITLE
Fix goroutine leaks

### DIFF
--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -334,8 +334,8 @@ func (f *httpForwarder) serveWebSocket(w http.ResponseWriter, req *http.Request,
 	defer underlyingConn.Close()
 	defer targetConn.Close()
 
-	errClient := make(chan error)
-	errBackend := make(chan error)
+	errClient := make(chan error, 1)
+	errBackend := make(chan error, 1)
 	replicateWebsocketConn := func(dst, src *websocket.Conn, errc chan error) {
 		for {
 			msgType, msg, err := src.ReadMessage()


### PR DESCRIPTION
Fix a leak in websocket

To explain:

We have two goroutines, one for the connection with the backend, and one for the connection with the client.

If an error occurs on one of the goroutines, we close both connection. By buffering the err channel, we can ignore the error on the goroutine which occurs because we close the connection intentionally.