### PR TITLE
Fix bug introduced with #99

### DIFF
--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -221,7 +221,9 @@ func New(setters ...optSetter) (*Forwarder, error) {
 	}
 
 	if f.tlsClientConfig == nil {
-		f.tlsClientConfig = f.httpForwarder.roundTripper.(*http.Transport).TLSClientConfig
+		if ht, ok := f.httpForwarder.roundTripper.(*http.Transport); ok {
+			f.tlsClientConfig = ht.TLSClientConfig
+		}
 	}
 
 	f.httpForwarder.roundTripper = ErrorHandlingRoundTripper{


### PR DESCRIPTION
Only set tlsClientConfig from the roundtripper if it is a http.Transport

The 4ce46c197bfa755a828cf04a083e20291f98f590 commit by @Juliens introduced a bug that forces a configured RoundTripper in forward to have to be a `*http.Transport` (vs generically a `http.RoundTripper`).

https://github.com/vulcand/oxy/commit/4ce46c197bfa755a828cf04a083e20291f98f590#diff-d86a3ca91dd50cb2fd715e585145d6dcR168

This PR just makes this optional.
