### PR TITLE
fix typo of completed (competed)

### DIFF
--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -199,7 +199,7 @@ func (b *Buffer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if log.GetLevel() >= log.DebugLevel {
 		logEntry := log.WithField("Request", utils.DumpHttpRequest(req))
 		logEntry.Debug("vulcand/oxy/buffer: begin ServeHttp on request")
-		defer logEntry.Debug("vulcand/oxy/buffer: competed ServeHttp on request")
+		defer logEntry.Debug("vulcand/oxy/buffer: completed ServeHttp on request")
 	}
 
 	if err := b.checkLimit(req); err != nil {

--- a/cbreaker/cbreaker.go
+++ b/cbreaker/cbreaker.go
@@ -103,7 +103,7 @@ func (c *CircuitBreaker) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if log.GetLevel() >= log.DebugLevel {
 		logEntry := log.WithField("Request", utils.DumpHttpRequest(req))
 		logEntry.Debug("vulcand/oxy/circuitbreaker: begin ServeHttp on request")
-		defer logEntry.Debug("vulcand/oxy/circuitbreaker: competed ServeHttp on request")
+		defer logEntry.Debug("vulcand/oxy/circuitbreaker: completed ServeHttp on request")
 	}
 	if c.activateFallback(w, req) {
 		c.fallback.ServeHTTP(w, req)

--- a/cbreaker/fallback.go
+++ b/cbreaker/fallback.go
@@ -31,7 +31,7 @@ func (f *ResponseFallback) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if log.GetLevel() >= log.DebugLevel {
 		logEntry := log.WithField("Request", utils.DumpHttpRequest(req))
 		logEntry.Debug("vulcand/oxy/fallback/response: begin ServeHttp on request")
-		defer logEntry.Debug("vulcand/oxy/fallback/response: competed ServeHttp on request")
+		defer logEntry.Debug("vulcand/oxy/fallback/response: completed ServeHttp on request")
 	}
 
 	if f.r.ContentType != "" {
@@ -67,7 +67,7 @@ func (f *RedirectFallback) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if log.GetLevel() >= log.DebugLevel {
 		logEntry := log.WithField("Request", utils.DumpHttpRequest(req))
 		logEntry.Debug("vulcand/oxy/fallback/redirect: begin ServeHttp on request")
-		defer logEntry.Debug("vulcand/oxy/fallback/redirect: competed ServeHttp on request")
+		defer logEntry.Debug("vulcand/oxy/fallback/redirect: completed ServeHttp on request")
 	}
 
 	location := f.u.String()

--- a/connlimit/connlimit.go
+++ b/connlimit/connlimit.go
@@ -110,7 +110,7 @@ func (e *ConnErrHandler) ServeHTTP(w http.ResponseWriter, req *http.Request, err
 	if log.GetLevel() >= log.DebugLevel {
 		logEntry := log.WithField("Request", utils.DumpHttpRequest(req))
 		logEntry.Debug("vulcand/oxy/connlimit: begin ServeHttp on request")
-		defer logEntry.Debug("vulcand/oxy/connlimit: competed ServeHttp on request")
+		defer logEntry.Debug("vulcand/oxy/connlimit: completed ServeHttp on request")
 	}
 
 	if _, ok := err.(*MaxConnError); ok {

--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -302,7 +302,7 @@ func (f *httpForwarder) serveWebSocket(w http.ResponseWriter, req *http.Request,
 	if f.log.GetLevel() >= log.DebugLevel {
 		logEntry := f.log.WithField("Request", utils.DumpHttpRequest(req))
 		logEntry.Debug("vulcand/oxy/forward/websocket: begin ServeHttp on request")
-		defer logEntry.Debug("vulcand/oxy/forward/websocket: competed ServeHttp on request")
+		defer logEntry.Debug("vulcand/oxy/forward/websocket: completed ServeHttp on request")
 	}
 
 	outReq := f.copyWebSocketRequest(req)

--- a/roundrobin/rebalancer.go
+++ b/roundrobin/rebalancer.go
@@ -145,7 +145,7 @@ func (rb *Rebalancer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if log.GetLevel() >= log.DebugLevel {
 		logEntry := log.WithField("Request", utils.DumpHttpRequest(req))
 		logEntry.Debug("vulcand/oxy/roundrobin/rebalancer: begin ServeHttp on request")
-		defer logEntry.Debug("vulcand/oxy/roundrobin/rebalancer: competed ServeHttp on request")
+		defer logEntry.Debug("vulcand/oxy/roundrobin/rebalancer: completed ServeHttp on request")
 	}
 
 	pw := &utils.ProxyWriter{W: w}

--- a/roundrobin/rr.go
+++ b/roundrobin/rr.go
@@ -84,7 +84,7 @@ func (r *RoundRobin) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if log.GetLevel() >= log.DebugLevel {
 		logEntry := log.WithField("Request", utils.DumpHttpRequest(req))
 		logEntry.Debug("vulcand/oxy/roundrobin/rr: begin ServeHttp on request")
-		defer logEntry.Debug("vulcand/oxy/roundrobin/rr: competed ServeHttp on request")
+		defer logEntry.Debug("vulcand/oxy/roundrobin/rr: completed ServeHttp on request")
 	}
 
 	// make shallow copy of request before chaning anything to avoid side effects

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -85,7 +85,7 @@ func (s *Stream) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if log.GetLevel() >= log.DebugLevel {
 		logEntry := log.WithField("Request", utils.DumpHttpRequest(req))
 		logEntry.Debug("vulcand/oxy/stream: begin ServeHttp on request")
-		defer logEntry.Debug("vulcand/oxy/stream: competed ServeHttp on request")
+		defer logEntry.Debug("vulcand/oxy/stream: completed ServeHttp on request")
 	}
 
 	s.next.ServeHTTP(w, req)


### PR DESCRIPTION
while debugging an issue with `traefik`, I noticed a typo in the debug logs

```
time="2018-03-30T00:06:05Z" level=debug msg="vulcand/oxy/forward/http: completed ServeHttp on request"
time="2018-03-30T00:06:05Z" level=debug msg="vulcand/oxy/forward: completed ServeHttp on request"
time="2018-03-30T00:06:05Z" level=debug msg="vulcand/oxy/roundrobin/rebalancer: competed ServeHttp on request"
```

two say `completed`, one says `competed`