### PR TITLE
Disable closeNotify when method GET for http pipelining

### DIFF
--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -4,6 +4,7 @@
 package forward
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -294,6 +295,12 @@ func (f *httpForwarder) modifyRequest(outReq *http.Request, target *url.URL) {
 
 	if f.rewriter != nil {
 		f.rewriter.Rewrite(outReq)
+	}
+
+	// Disable closeNotify when method GET for http pipelining
+	if outReq.Method == http.MethodGet {
+		quietReq := outReq.WithContext(context.Background())
+		*outReq = *quietReq
 	}
 }
 


### PR DESCRIPTION
`httputil.ReverseProxy` handle `CloseNotify`, but it generates some bugs with http pipelining (used by apt or svn for example). 

An issue is open on golang https://github.com/golang/go/issues/23921.
As we don't know when it will be fix we have to disable the closenotify by overriding the current request context.