### PR TITLE
Remove golang master and add golang 1.x in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 go:
   - 1.8.x
   - 1.9.x
-  - master
+  - 1.x
 
 sudo: false
 


### PR DESCRIPTION
Tests failed in golang master because master is not stable.