### PR TITLE
If forwarded port is not known, try to find it with x-forwarded-proto

### DIFF
--- a/forward/rewrite.go
+++ b/forward/rewrite.go
@@ -85,6 +85,10 @@ func forwardedPort(req *http.Request) string {
 		return port
 	}
 
+	if req.Header.Get(XForwardedProto) == "https" {
+		return "443"
+	}
+
 	if req.TLS != nil {
 		return "443"
 	}


### PR DESCRIPTION
The issue

My front load balancer (Google LB) doesn't set the X-Forwarded-Port header and my reverse proxy is not using TLS, that result with a X-Forwarded-Port set to 80 in my backend application.

The solution (@mouminoux)

I think that if X-Forwarded-Proto is set and the X-Forwarded-Port isn't, we should try to guess the port with X-Forwarded-Proto header before reverse proxy connection type (TLS).