### PR TITLE
Copies the writer's headers before the upgrade

### DIFF
--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -351,6 +351,7 @@ func (f *httpForwarder) serveWebSocket(w http.ResponseWriter, req *http.Request,
 	}}
 
 	utils.RemoveHeaders(resp.Header, WebsocketUpgradeHeaders...)
+	utils.CopyHeaders(resp.Header, w.Header())
 
 	underlyingConn, err := upgrader.Upgrade(w, req, resp.Header)
 	if err != nil {


### PR DESCRIPTION
Headers that are in the `httpResponseWriter` given to `serveWebSocket`are not copied before the upgrade call, hence are not sent to the client.

This PR copies the header before the Upgrade.