### PR TITLE
Send "Retry-After" to comply with RFC6585

### DIFF
--- a/ratelimit/tokenlimiter.go
+++ b/ratelimit/tokenlimiter.go
@@ -181,6 +181,7 @@ type RateErrHandler struct {
 func (e *RateErrHandler) ServeHTTP(w http.ResponseWriter, req *http.Request, err error) {
 	if rerr, ok := err.(*MaxRateError); ok {
 		w.Header().Set("Retry-After", fmt.Sprintf("%.0f", rerr.delay.Seconds()))
+		w.Header().Set("X-Retry-In", rerr.delay.String())
 		w.WriteHeader(http.StatusTooManyRequests)
 		w.Write([]byte(err.Error()))
 		return

--- a/ratelimit/tokenlimiter.go
+++ b/ratelimit/tokenlimiter.go
@@ -180,8 +180,8 @@ type RateErrHandler struct {
 
 func (e *RateErrHandler) ServeHTTP(w http.ResponseWriter, req *http.Request, err error) {
 	if rerr, ok := err.(*MaxRateError); ok {
-		w.Header().Set("X-Retry-In", rerr.delay.String())
-		w.WriteHeader(429)
+		w.Header().Set("Retry-After", fmt.Sprintf("%.0f", rerr.delay.Seconds()))
+		w.WriteHeader(http.StatusTooManyRequests)
 		w.Write([]byte(err.Error()))
 		return
 	}


### PR DESCRIPTION
This is related to #139.

It makes sure we send the Retry-After "hint" in the correct format.