### PR TITLE
Linting

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -74,18 +74,6 @@
   version = "v1.1.4"
 
 [[projects]]
-  branch = "master"
-  name = "github.com/vulcand/oxy"
-  packages = [
-    "forward",
-    "memmetrics",
-    "roundrobin",
-    "testutils",
-    "utils"
-  ]
-  revision = "adbef6bedf021985587c3c18c9d4b84b2d78f67c"
-
-[[projects]]
   name = "github.com/vulcand/predicate"
   packages = ["."]
   revision = "939c094524d124c55fa8afe0e077701db4a865e2"
@@ -133,6 +121,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d6d09a04812ccfb9e10cbc0f613c7efbe589205a775ce9f60b81041d41544f2a"
+  inputs-digest = "13c58913794cb91ced539fc4dcde957f6664b82ed886d245ca769960327f7e7f"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 .PHONY: all
 
 PKGS := $(shell go list ./... | grep -v '/vendor/')
+GOFILES := $(shell go list -f '{{range $$index, $$element := .GoFiles}}{{$$.Dir}}/{{$$element}}{{"\n"}}{{end}}' ./... | grep -v '/vendor/')
 TXT_FILES := $(shell find * -type f -not -path 'vendor/**')
 
-default: clean misspell vet test
+default: clean misspell vet check-fmt test
 
 test: clean
 	go test -race -cover $(PKGS)
@@ -26,9 +27,7 @@ vet:
 	go vet $(PKGS)
 
 checks: vet lint check-fmt
-	echo "staticcheck:"
 	staticcheck $(PKGS)
-	echo "gosimple:"
 	gosimple $(PKGS)
 
 check-fmt: SHELL := /bin/bash

--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -167,7 +167,7 @@ func MaxRequestBodyBytes(m int64) optSetter {
 	}
 }
 
-// MaxRequestBody bytes sets the maximum request body to be stored in memory
+// MemRequestBodyBytes bytes sets the maximum request body to be stored in memory
 // buffer middleware will serialize the excess to disk.
 func MemRequestBodyBytes(m int64) optSetter {
 	return func(b *Buffer) error {
@@ -391,7 +391,7 @@ func (b *bufferWriter) WriteHeader(code int) {
 	b.code = code
 }
 
-//CloseNotifier interface - this allows downstream connections to be terminated when the client terminates.
+// CloseNotifier interface - this allows downstream connections to be terminated when the client terminates.
 func (b *bufferWriter) CloseNotify() <-chan bool {
 	if cn, ok := b.responseWriter.(http.CloseNotifier); ok {
 		return cn.CloseNotify()
@@ -400,7 +400,7 @@ func (b *bufferWriter) CloseNotify() <-chan bool {
 	return make(<-chan bool)
 }
 
-//This allows connections to be hijacked for websockets for instance.
+// Hijack This allows connections to be hijacked for websockets for instance.
 func (b *bufferWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	if hi, ok := b.responseWriter.(http.Hijacker); ok {
 		conn, rw, err := hi.Hijack()
@@ -413,8 +413,8 @@ func (b *bufferWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	return nil, nil, fmt.Errorf("The response writer that was wrapped in this proxy, does not implement http.Hijacker. It is of type: %v", reflect.TypeOf(b.responseWriter))
 }
 
-type SizeErrHandler struct {
-}
+// SizeErrHandler Size error handler
+type SizeErrHandler struct{}
 
 func (e *SizeErrHandler) ServeHTTP(w http.ResponseWriter, req *http.Request, err error) {
 	if _, ok := err.(*multibuf.MaxSizeReachedError); ok {

--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -36,13 +36,12 @@ Examples of a buffering middleware:
 package buffer
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net/http"
-
-	"bufio"
 	"net"
+	"net/http"
 	"reflect"
 
 	"github.com/mailgun/multibuf"
@@ -307,7 +306,7 @@ func (b *Buffer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			return
 		}
 
-		attempt += 1
+		attempt++
 		if body != nil {
 			if _, err := body.Seek(0, 0); err != nil {
 				b.log.Errorf("vulcand/oxy/buffer: failed to rewind response body, err: %v", err)

--- a/buffer/threshold.go
+++ b/buffer/threshold.go
@@ -7,6 +7,7 @@ import (
 	"github.com/vulcand/predicate"
 )
 
+// IsValidExpression check if it's a valid expression
 func IsValidExpression(expr string) bool {
 	_, err := parseExpression(expr)
 	return err == nil

--- a/cbreaker/cbreaker.go
+++ b/cbreaker/cbreaker.go
@@ -31,9 +31,8 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/sirupsen/logrus"
-
 	"github.com/mailgun/timetools"
+	log "github.com/sirupsen/logrus"
 	"github.com/vulcand/oxy/memmetrics"
 	"github.com/vulcand/oxy/utils"
 )
@@ -359,8 +358,7 @@ const (
 
 var defaultFallback = &fallback{}
 
-type fallback struct {
-}
+type fallback struct{}
 
 func (f *fallback) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	w.WriteHeader(http.StatusServiceUnavailable)

--- a/cbreaker/cbreaker.go
+++ b/cbreaker/cbreaker.go
@@ -3,7 +3,7 @@
 // Vulcan circuit breaker watches the error condtion to match
 // after which it activates the fallback scenario, e.g. returns the response code
 // or redirects the request to another location
-
+//
 // Circuit breakers start in the Standby state first, observing responses and watching location metrics.
 //
 // Once the Circuit breaker condition is met, it enters the "Tripped" state, where it activates fallback scenario
@@ -124,6 +124,7 @@ func (c *CircuitBreaker) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	c.serve(w, req)
 }
 
+// Wrap sets the next handler to be called by circuit breaker handler.
 func (c *CircuitBreaker) Wrap(next http.Handler) {
 	c.next = next
 }
@@ -308,7 +309,7 @@ func OnTripped(s SideEffect) CircuitBreakerOption {
 	}
 }
 
-// OnTripped sets a SideEffect to run when entering the Standby state.
+// OnStandby sets a SideEffect to run when entering the Standby state.
 // Only one SideEffect can be set for this hook.
 func OnStandby(s SideEffect) CircuitBreakerOption {
 	return func(c *CircuitBreaker) error {

--- a/cbreaker/effect.go
+++ b/cbreaker/effect.go
@@ -13,10 +13,12 @@ import (
 	"github.com/vulcand/oxy/utils"
 )
 
+// SideEffect a side effect
 type SideEffect interface {
 	Exec() error
 }
 
+// Webhook Web hook
 type Webhook struct {
 	URL     string
 	Method  string
@@ -25,12 +27,14 @@ type Webhook struct {
 	Body    []byte
 }
 
+// WebhookSideEffect a web hook side effect
 type WebhookSideEffect struct {
 	w Webhook
 
 	log *log.Logger
 }
 
+// NewWebhookSideEffectsWithLogger creates a new WebhookSideEffect
 func NewWebhookSideEffectsWithLogger(w Webhook, l *log.Logger) (*WebhookSideEffect, error) {
 	if w.Method == "" {
 		return nil, fmt.Errorf("Supply method")
@@ -43,6 +47,7 @@ func NewWebhookSideEffectsWithLogger(w Webhook, l *log.Logger) (*WebhookSideEffe
 	return &WebhookSideEffect{w: w, log: l}, nil
 }
 
+// NewWebhookSideEffect creates a new WebhookSideEffect
 func NewWebhookSideEffect(w Webhook) (*WebhookSideEffect, error) {
 	return NewWebhookSideEffectsWithLogger(w, log.StandardLogger())
 }
@@ -57,6 +62,7 @@ func (w *WebhookSideEffect) getBody() io.Reader {
 	return nil
 }
 
+// Exec execute the side effect
 func (w *WebhookSideEffect) Exec() error {
 	r, err := http.NewRequest(w.w.Method, w.w.URL, w.getBody())
 	if err != nil {

--- a/cbreaker/fallback.go
+++ b/cbreaker/fallback.go
@@ -10,18 +10,21 @@ import (
 	"github.com/vulcand/oxy/utils"
 )
 
+// Response response model
 type Response struct {
 	StatusCode  int
 	ContentType string
 	Body        []byte
 }
 
+// ResponseFallback fallback response handler
 type ResponseFallback struct {
 	r Response
 
 	log *log.Logger
 }
 
+// NewResponseFallbackWithLogger creates a new ResponseFallback
 func NewResponseFallbackWithLogger(r Response, l *log.Logger) (*ResponseFallback, error) {
 	if r.StatusCode == 0 {
 		return nil, fmt.Errorf("response code should not be 0")
@@ -29,6 +32,7 @@ func NewResponseFallbackWithLogger(r Response, l *log.Logger) (*ResponseFallback
 	return &ResponseFallback{r: r, log: l}, nil
 }
 
+// NewResponseFallback creates a new ResponseFallback
 func NewResponseFallback(r Response) (*ResponseFallback, error) {
 	return NewResponseFallbackWithLogger(r, log.StandardLogger())
 }
@@ -51,11 +55,13 @@ func (f *ResponseFallback) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 }
 
+// Redirect redirect model
 type Redirect struct {
 	URL          string
 	PreservePath bool
 }
 
+// RedirectFallback fallback redirect handler
 type RedirectFallback struct {
 	r Redirect
 
@@ -64,6 +70,7 @@ type RedirectFallback struct {
 	log *log.Logger
 }
 
+// NewRedirectFallbackWithLogger creates a new RedirectFallback
 func NewRedirectFallbackWithLogger(r Redirect, l *log.Logger) (*RedirectFallback, error) {
 	u, err := url.ParseRequestURI(r.URL)
 	if err != nil {
@@ -72,6 +79,7 @@ func NewRedirectFallbackWithLogger(r Redirect, l *log.Logger) (*RedirectFallback
 	return &RedirectFallback{r: r, u: u, log: l}, nil
 }
 
+// NewRedirectFallback creates a new RedirectFallback
 func NewRedirectFallback(r Redirect) (*RedirectFallback, error) {
 	return NewRedirectFallbackWithLogger(r, log.StandardLogger())
 }

--- a/connlimit/connlimit.go
+++ b/connlimit/connlimit.go
@@ -1,4 +1,4 @@
-// package connlimit provides control over simultaneous connections coming from the same source
+// Package connlimit provides control over simultaneous connections coming from the same source
 package connlimit
 
 import (
@@ -10,7 +10,7 @@ import (
 	"github.com/vulcand/oxy/utils"
 )
 
-// Limiter tracks concurrent connection per token
+// ConnLimiter tracks concurrent connection per token
 // and is capable of rejecting connections if they are failed
 type ConnLimiter struct {
 	mutex            *sync.Mutex
@@ -24,6 +24,7 @@ type ConnLimiter struct {
 	log        *log.Logger
 }
 
+// New creates a new ConnLimiter
 func New(next http.Handler, extract utils.SourceExtractor, maxConnections int64, options ...ConnLimitOption) (*ConnLimiter, error) {
 	if extract == nil {
 		return nil, fmt.Errorf("Extract function can not be nil")
@@ -60,6 +61,7 @@ func Logger(l *log.Logger) ConnLimitOption {
 	}
 }
 
+// Wrap sets the next handler to be called by connexion limiter handler.
 func (cl *ConnLimiter) Wrap(h http.Handler) {
 	cl.next = h
 }
@@ -109,6 +111,7 @@ func (cl *ConnLimiter) release(token string, amount int64) {
 	}
 }
 
+// MaxConnError maximum connections reached error
 type MaxConnError struct {
 	max int64
 }
@@ -117,6 +120,7 @@ func (m *MaxConnError) Error() string {
 	return fmt.Sprintf("max connections reached: %d", m.max)
 }
 
+// ConnErrHandler connection limiter error handler
 type ConnErrHandler struct {
 	log *log.Logger
 }
@@ -136,6 +140,7 @@ func (e *ConnErrHandler) ServeHTTP(w http.ResponseWriter, req *http.Request, err
 	utils.DefaultHandler.ServeHTTP(w, req, err)
 }
 
+// ConnLimitOption connection limit option type
 type ConnLimitOption func(l *ConnLimiter) error
 
 // ErrorHandler sets error handler of the server

--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -1,4 +1,4 @@
-// package forwarder implements http handler that forwards requests to remote server
+// Package forward implements http handler that forwards requests to remote server
 // and serves back the response
 // websocket proxying support based on https://github.com/yhat/wsutil
 package forward
@@ -21,7 +21,7 @@ import (
 	"github.com/vulcand/oxy/utils"
 )
 
-// Oxy Logger interface of the internal
+// OxyLogger interface of the internal
 type OxyLogger interface {
 	log.FieldLogger
 	GetLevel() log.Level
@@ -42,8 +42,7 @@ type ReqRewriter interface {
 
 type optSetter func(f *Forwarder) error
 
-// PassHostHeader specifies if a client's Host header field should
-// be delegated
+// PassHostHeader specifies if a client's Host header field should be delegated
 func PassHostHeader(b bool) optSetter {
 	return func(f *Forwarder) error {
 		f.httpForwarder.passHost = b
@@ -68,8 +67,7 @@ func Rewriter(r ReqRewriter) optSetter {
 	}
 }
 
-// PassHostHeader specifies if a client's Host header field should
-// be delegated
+// WebsocketTLSClientConfig define the websocker client TLS configuration
 func WebsocketTLSClientConfig(tcc *tls.Config) optSetter {
 	return func(f *Forwarder) error {
 		f.httpForwarder.tlsClientConfig = tcc
@@ -120,6 +118,7 @@ func Logger(l log.FieldLogger) optSetter {
 	}
 }
 
+// StateListener defines a state listener for the HTTP forwarder
 func StateListener(stateListener UrlForwardingStateListener) optSetter {
 	return func(f *Forwarder) error {
 		f.stateListener = stateListener
@@ -127,6 +126,7 @@ func StateListener(stateListener UrlForwardingStateListener) optSetter {
 	}
 }
 
+// ResponseModifier defines a response modifier for the HTTP forwarder
 func ResponseModifier(responseModifier func(*http.Response) error) optSetter {
 	return func(f *Forwarder) error {
 		f.httpForwarder.modifyResponse = responseModifier
@@ -134,6 +134,7 @@ func ResponseModifier(responseModifier func(*http.Response) error) optSetter {
 	}
 }
 
+// StreamingFlushInterval defines a streaming flush interval for the HTTP forwarder
 func StreamingFlushInterval(flushInterval time.Duration) optSetter {
 	return func(f *Forwarder) error {
 		f.httpForwarder.flushInterval = flushInterval
@@ -141,11 +142,13 @@ func StreamingFlushInterval(flushInterval time.Duration) optSetter {
 	}
 }
 
+// ErrorHandlingRoundTripper a error handling round tripper
 type ErrorHandlingRoundTripper struct {
 	http.RoundTripper
 	errorHandler utils.ErrorHandler
 }
 
+// RoundTrip executes the round trip
 func (rt ErrorHandlingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	res, err := rt.RoundTripper.RoundTrip(req)
 	if err != nil {
@@ -188,12 +191,15 @@ type httpForwarder struct {
 	bufferPool httputil.BufferPool
 }
 
+const defaultFlushInterval = time.Duration(100) * time.Millisecond
+
+// Connection states
 const (
-	defaultFlushInterval = time.Duration(100) * time.Millisecond
-	StateConnected       = iota
+	StateConnected = iota
 	StateDisconnected
 )
 
+// UrlForwardingStateListener URL forwarding state listener
 type UrlForwardingStateListener func(*url.URL, int)
 
 // New creates an instance of Forwarder based on the provided list of configuration options
@@ -501,7 +507,7 @@ func (f *httpForwarder) serveHTTP(w http.ResponseWriter, inReq *http.Request, ct
 	}
 }
 
-// isWebsocketRequest determines if the specified HTTP request is a
+// IsWebsocketRequest determines if the specified HTTP request is a
 // websocket handshake request
 func IsWebsocketRequest(req *http.Request) bool {
 	containsHeader := func(name, value string) bool {

--- a/forward/fwd_test.go
+++ b/forward/fwd_test.go
@@ -344,6 +344,7 @@ func (s *FwdSuite) TestContextWithValueInErrHandler(c *C) {
 	defer proxy.Close()
 
 	re, _, err := testutils.Get(proxy.URL)
+	c.Assert(err, IsNil)
 	c.Assert(re.StatusCode, Equals, http.StatusBadGateway)
 	c.Assert(*originalPBool, Equals, true)
 }

--- a/forward/fwd_websocket_test.go
+++ b/forward/fwd_websocket_test.go
@@ -46,6 +46,7 @@ func (s *FwdSuite) TestWebSocketTCPClose(c *C) {
 		withServer(proxyAddr),
 		withPath("/ws"),
 	).open()
+	c.Assert(err, IsNil)
 	conn.Close()
 
 	serverErr := <-errChan
@@ -254,6 +255,7 @@ func (s *FwdSuite) TestWebSocketRequestWithHeadersInResponseWriter(c *C) {
 	webSocketURL := "ws://" + serverAddr + "/ws"
 	headers.Add("Origin", webSocketURL)
 	conn, resp, err := gorillawebsocket.DefaultDialer.Dial(webSocketURL, headers)
+	c.Assert(err, IsNil)
 	defer conn.Close()
 	if err != nil {
 		c.Errorf("Error [%s] during Dial with response: %+v", err, resp)

--- a/forward/headers.go
+++ b/forward/headers.go
@@ -1,5 +1,6 @@
 package forward
 
+// Headers
 const (
 	XForwardedProto        = "X-Forwarded-Proto"
 	XForwardedFor          = "X-Forwarded-For"
@@ -22,7 +23,7 @@ const (
 	SecWebsocketAccept     = "Sec-Websocket-Accept"
 )
 
-// Hop-by-hop headers. These are removed when sent to the backend.
+// HopHeaders Hop-by-hop headers. These are removed when sent to the backend.
 // http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html
 // Copied from reverseproxy.go, too bad
 var HopHeaders = []string{
@@ -36,6 +37,7 @@ var HopHeaders = []string{
 	Upgrade,
 }
 
+// WebsocketDialHeaders Websocket dial headers
 var WebsocketDialHeaders = []string{
 	Upgrade,
 	Connection,
@@ -45,6 +47,7 @@ var WebsocketDialHeaders = []string{
 	SecWebsocketAccept,
 }
 
+// WebsocketUpgradeHeaders Websocket upgrade headers
 var WebsocketUpgradeHeaders = []string{
 	Upgrade,
 	Connection,
@@ -52,6 +55,7 @@ var WebsocketUpgradeHeaders = []string{
 	SecWebsocketExtensions,
 }
 
+// XHeaders X-* headers
 var XHeaders = []string{
 	XForwardedProto,
 	XForwardedFor,

--- a/forward/rewrite.go
+++ b/forward/rewrite.go
@@ -8,7 +8,7 @@ import (
 	"github.com/vulcand/oxy/utils"
 )
 
-// Rewriter is responsible for removing hop-by-hop headers and setting forwarding headers
+// HeaderRewriter is responsible for removing hop-by-hop headers and setting forwarding headers
 type HeaderRewriter struct {
 	TrustForwardHeader bool
 	Hostname           string
@@ -19,6 +19,7 @@ func ipv6fix(clientIP string) string {
 	return strings.Split(clientIP, "%")[0]
 }
 
+// Rewrite rewrite request headers
 func (rw *HeaderRewriter) Rewrite(req *http.Request) {
 	if !rw.TrustForwardHeader {
 		utils.RemoveHeaders(req.Header, XHeaders...)

--- a/memmetrics/anomaly.go
+++ b/memmetrics/anomaly.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-// SplitRatios provides simple anomaly detection for requests latencies.
+// SplitLatencies provides simple anomaly detection for requests latencies.
 // it splits values into good or bad category based on the threshold and the median value.
 // If all values are not far from the median, it will return all values in 'good' set.
 // Precision is the smallest value to consider, e.g. if set to millisecond, microseconds will be ignored.

--- a/memmetrics/anomaly.go
+++ b/memmetrics/anomaly.go
@@ -23,10 +23,10 @@ func SplitLatencies(values []time.Duration, precision time.Duration) (good map[t
 	good, bad = make(map[time.Duration]bool), make(map[time.Duration]bool)
 	// Note that multiplier makes this function way less sensitive than ratios detector, this is to avoid noise.
 	vgood, vbad := SplitFloat64(2, 0, ratios)
-	for r, _ := range vgood {
+	for r := range vgood {
 		good[v2r[r]] = true
 	}
-	for r, _ := range vbad {
+	for r := range vbad {
 		bad[v2r[r]] = true
 	}
 	return good, bad

--- a/memmetrics/counter.go
+++ b/memmetrics/counter.go
@@ -9,6 +9,7 @@ import (
 
 type rcOptSetter func(*RollingCounter) error
 
+// CounterClock defines a counter clock
 func CounterClock(c timetools.TimeProvider) rcOptSetter {
 	return func(r *RollingCounter) error {
 		r.clock = c
@@ -16,7 +17,7 @@ func CounterClock(c timetools.TimeProvider) rcOptSetter {
 	}
 }
 
-// Calculates in memory failure rate of an endpoint using rolling window of a predefined size
+// RollingCounter Calculates in memory failure rate of an endpoint using rolling window of a predefined size
 type RollingCounter struct {
 	clock          timetools.TimeProvider
 	resolution     time.Duration
@@ -57,11 +58,13 @@ func NewCounter(buckets int, resolution time.Duration, options ...rcOptSetter) (
 	return rc, nil
 }
 
+// Append append a counter
 func (c *RollingCounter) Append(o *RollingCounter) error {
 	c.Inc(int(o.Count()))
 	return nil
 }
 
+// Clone clone a counter
 func (c *RollingCounter) Clone() *RollingCounter {
 	c.cleanup()
 	other := &RollingCounter{
@@ -75,6 +78,7 @@ func (c *RollingCounter) Clone() *RollingCounter {
 	return other
 }
 
+// Reset reset a counter
 func (c *RollingCounter) Reset() {
 	c.lastBucket = -1
 	c.countedBuckets = 0
@@ -84,27 +88,33 @@ func (c *RollingCounter) Reset() {
 	}
 }
 
+// CountedBuckets gets counted buckets
 func (c *RollingCounter) CountedBuckets() int {
 	return c.countedBuckets
 }
 
+// Count counts
 func (c *RollingCounter) Count() int64 {
 	c.cleanup()
 	return c.sum()
 }
 
+// Resolution gets resolution
 func (c *RollingCounter) Resolution() time.Duration {
 	return c.resolution
 }
 
+// Buckets gets buckets
 func (c *RollingCounter) Buckets() int {
 	return len(c.values)
 }
 
+// WindowSize gets windows size
 func (c *RollingCounter) WindowSize() time.Duration {
 	return time.Duration(len(c.values)) * c.resolution
 }
 
+// Inc increment counter
 func (c *RollingCounter) Inc(v int) {
 	c.cleanup()
 	c.incBucketValue(v)

--- a/memmetrics/histogram.go
+++ b/memmetrics/histogram.go
@@ -20,6 +20,7 @@ type HDRHistogram struct {
 	h *hdrhistogram.Histogram
 }
 
+// NewHDRHistogram creates a new HDRHistogram
 func NewHDRHistogram(low, high int64, sigfigs int) (h *HDRHistogram, err error) {
 	defer func() {
 		if msg := recover(); msg != nil {
@@ -34,6 +35,7 @@ func NewHDRHistogram(low, high int64, sigfigs int) (h *HDRHistogram, err error) 
 	}, nil
 }
 
+// Export export a HDRHistogram
 func (h *HDRHistogram) Export() *HDRHistogram {
 	var hist *hdrhistogram.Histogram
 	if h.h != nil {
@@ -43,28 +45,32 @@ func (h *HDRHistogram) Export() *HDRHistogram {
 	return &HDRHistogram{low: h.low, high: h.high, sigfigs: h.sigfigs, h: hist}
 }
 
-// Returns latency at quantile with microsecond precision
+// LatencyAtQuantile sets latency at quantile with microsecond precision
 func (h *HDRHistogram) LatencyAtQuantile(q float64) time.Duration {
 	return time.Duration(h.ValueAtQuantile(q)) * time.Microsecond
 }
 
-// Records latencies with microsecond precision
+// RecordLatencies Records latencies with microsecond precision
 func (h *HDRHistogram) RecordLatencies(d time.Duration, n int64) error {
 	return h.RecordValues(int64(d/time.Microsecond), n)
 }
 
+// Reset reset a HDRHistogram
 func (h *HDRHistogram) Reset() {
 	h.h.Reset()
 }
 
+// ValueAtQuantile sets value at quantile
 func (h *HDRHistogram) ValueAtQuantile(q float64) int64 {
 	return h.h.ValueAtQuantile(q)
 }
 
+// RecordValues sets record values
 func (h *HDRHistogram) RecordValues(v, n int64) error {
 	return h.h.RecordValues(v, n)
 }
 
+// Merge merge a HDRHistogram
 func (h *HDRHistogram) Merge(other *HDRHistogram) error {
 	if other == nil {
 		return fmt.Errorf("other is nil")
@@ -75,6 +81,7 @@ func (h *HDRHistogram) Merge(other *HDRHistogram) error {
 
 type rhOptSetter func(r *RollingHDRHistogram) error
 
+// RollingClock sets a clock
 func RollingClock(clock timetools.TimeProvider) rhOptSetter {
 	return func(r *RollingHDRHistogram) error {
 		r.clock = clock
@@ -82,7 +89,7 @@ func RollingClock(clock timetools.TimeProvider) rhOptSetter {
 	}
 }
 
-// RollingHistogram holds multiple histograms and rotates every period.
+// RollingHDRHistogram holds multiple histograms and rotates every period.
 // It provides resulting histogram as a result of a call of 'Merged' function.
 type RollingHDRHistogram struct {
 	idx         int
@@ -96,6 +103,7 @@ type RollingHDRHistogram struct {
 	clock       timetools.TimeProvider
 }
 
+// NewRollingHDRHistogram created a new RollingHDRHistogram
 func NewRollingHDRHistogram(low, high int64, sigfigs int, period time.Duration, bucketCount int, options ...rhOptSetter) (*RollingHDRHistogram, error) {
 	rh := &RollingHDRHistogram{
 		bucketCount: bucketCount,
@@ -127,6 +135,7 @@ func NewRollingHDRHistogram(low, high int64, sigfigs int, period time.Duration, 
 	return rh, nil
 }
 
+// Export export a RollingHDRHistogram
 func (r *RollingHDRHistogram) Export() *RollingHDRHistogram {
 	export := &RollingHDRHistogram{}
 	export.idx = r.idx
@@ -147,6 +156,7 @@ func (r *RollingHDRHistogram) Export() *RollingHDRHistogram {
 	return export
 }
 
+// Append append a RollingHDRHistogram
 func (r *RollingHDRHistogram) Append(o *RollingHDRHistogram) error {
 	if r.bucketCount != o.bucketCount || r.period != o.period || r.low != o.low || r.high != o.high || r.sigfigs != o.sigfigs {
 		return fmt.Errorf("can't merge")
@@ -160,6 +170,7 @@ func (r *RollingHDRHistogram) Append(o *RollingHDRHistogram) error {
 	return nil
 }
 
+// Reset reset a RollingHDRHistogram
 func (r *RollingHDRHistogram) Reset() {
 	r.idx = 0
 	r.lastRoll = r.clock.UtcNow()
@@ -173,6 +184,7 @@ func (r *RollingHDRHistogram) rotate() {
 	r.buckets[r.idx].Reset()
 }
 
+// Merged gets merged histogram
 func (r *RollingHDRHistogram) Merged() (*HDRHistogram, error) {
 	m, err := NewHDRHistogram(r.low, r.high, r.sigfigs)
 	if err != nil {
@@ -194,10 +206,12 @@ func (r *RollingHDRHistogram) getHist() *HDRHistogram {
 	return r.buckets[r.idx]
 }
 
+// RecordLatencies sets records latencies
 func (r *RollingHDRHistogram) RecordLatencies(v time.Duration, n int64) error {
 	return r.getHist().RecordLatencies(v, n)
 }
 
+// RecordValues set record values
 func (r *RollingHDRHistogram) RecordValues(v, n int64) error {
 	return r.getHist().RecordValues(v, n)
 }

--- a/memmetrics/histogram.go
+++ b/memmetrics/histogram.go
@@ -34,13 +34,13 @@ func NewHDRHistogram(low, high int64, sigfigs int) (h *HDRHistogram, err error) 
 	}, nil
 }
 
-func (r *HDRHistogram) Export() *HDRHistogram {
-	var hist *hdrhistogram.Histogram = nil
-	if r.h != nil {
-		snapshot := r.h.Export()
+func (h *HDRHistogram) Export() *HDRHistogram {
+	var hist *hdrhistogram.Histogram
+	if h.h != nil {
+		snapshot := h.h.Export()
 		hist = hdrhistogram.Import(snapshot)
 	}
-	return &HDRHistogram{low: r.low, high: r.high, sigfigs: r.sigfigs, h: hist}
+	return &HDRHistogram{low: h.low, high: h.high, sigfigs: h.sigfigs, h: hist}
 }
 
 // Returns latency at quantile with microsecond precision

--- a/memmetrics/ratio.go
+++ b/memmetrics/ratio.go
@@ -8,6 +8,7 @@ import (
 
 type ratioOptSetter func(r *RatioCounter) error
 
+// RatioClock sets a clock
 func RatioClock(clock timetools.TimeProvider) ratioOptSetter {
 	return func(r *RatioCounter) error {
 		r.clock = clock
@@ -22,6 +23,7 @@ type RatioCounter struct {
 	b     *RollingCounter
 }
 
+// NewRatioCounter creates a new RatioCounter
 func NewRatioCounter(buckets int, resolution time.Duration, options ...ratioOptSetter) (*RatioCounter, error) {
 	rc := &RatioCounter{}
 
@@ -50,39 +52,48 @@ func NewRatioCounter(buckets int, resolution time.Duration, options ...ratioOptS
 	return rc, nil
 }
 
+// Reset reset the counter
 func (r *RatioCounter) Reset() {
 	r.a.Reset()
 	r.b.Reset()
 }
 
+// IsReady returns true if the counter is ready
 func (r *RatioCounter) IsReady() bool {
 	return r.a.countedBuckets+r.b.countedBuckets >= len(r.a.values)
 }
 
+// CountA gets count A
 func (r *RatioCounter) CountA() int64 {
 	return r.a.Count()
 }
 
+// CountB gets count B
 func (r *RatioCounter) CountB() int64 {
 	return r.b.Count()
 }
 
+// Resolution gets resolution
 func (r *RatioCounter) Resolution() time.Duration {
 	return r.a.Resolution()
 }
 
+// Buckets gets buckets
 func (r *RatioCounter) Buckets() int {
 	return r.a.Buckets()
 }
 
+// WindowSize gets windows size
 func (r *RatioCounter) WindowSize() time.Duration {
 	return r.a.WindowSize()
 }
 
+// ProcessedCount gets processed count
 func (r *RatioCounter) ProcessedCount() int64 {
 	return r.CountA() + r.CountB()
 }
 
+// Ratio gets ratio
 func (r *RatioCounter) Ratio() float64 {
 	a := r.a.Count()
 	b := r.b.Count()
@@ -93,28 +104,34 @@ func (r *RatioCounter) Ratio() float64 {
 	return float64(a) / float64(a+b)
 }
 
+// IncA increment counter A
 func (r *RatioCounter) IncA(v int) {
 	r.a.Inc(v)
 }
 
+// IncB increment counter B
 func (r *RatioCounter) IncB(v int) {
 	r.b.Inc(v)
 }
 
+// TestMeter a test meter
 type TestMeter struct {
 	Rate       float64
 	NotReady   bool
 	WindowSize time.Duration
 }
 
+// GetWindowSize gets windows size
 func (tm *TestMeter) GetWindowSize() time.Duration {
 	return tm.WindowSize
 }
 
+// IsReady returns true if the meter is ready
 func (tm *TestMeter) IsReady() bool {
 	return !tm.NotReady
 }
 
+// GetRate gets rate
 func (tm *TestMeter) GetRate() float64 {
 	return tm.Rate
 }

--- a/memmetrics/roundtrip.go
+++ b/memmetrics/roundtrip.go
@@ -29,10 +29,16 @@ type RTMetrics struct {
 
 type rrOptSetter func(r *RTMetrics) error
 
+// NewRTMetricsFn builder function type
 type NewRTMetricsFn func() (*RTMetrics, error)
+
+// NewCounterFn builder function type
 type NewCounterFn func() (*RollingCounter, error)
+
+// NewRollingHistogramFn builder function type
 type NewRollingHistogramFn func() (*RollingHDRHistogram, error)
 
+// RTCounter set a builder function for Counter
 func RTCounter(new NewCounterFn) rrOptSetter {
 	return func(r *RTMetrics) error {
 		r.newCounter = new
@@ -40,13 +46,15 @@ func RTCounter(new NewCounterFn) rrOptSetter {
 	}
 }
 
-func RTHistogram(new NewRollingHistogramFn) rrOptSetter {
+// RTHistogram set a builder function for RollingHistogram
+func RTHistogram(fn NewRollingHistogramFn) rrOptSetter {
 	return func(r *RTMetrics) error {
-		r.newHist = new
+		r.newHist = fn
 		return nil
 	}
 }
 
+// RTClock sets a clock
 func RTClock(clock timetools.TimeProvider) rrOptSetter {
 	return func(r *RTMetrics) error {
 		r.clock = clock
@@ -103,7 +111,7 @@ func NewRTMetrics(settings ...rrOptSetter) (*RTMetrics, error) {
 	return m, nil
 }
 
-// Returns a new RTMetrics which is a copy of the current one
+// Export Returns a new RTMetrics which is a copy of the current one
 func (m *RTMetrics) Export() *RTMetrics {
 	m.statusCodesLock.RLock()
 	defer m.statusCodesLock.RUnlock()
@@ -130,11 +138,12 @@ func (m *RTMetrics) Export() *RTMetrics {
 	return export
 }
 
+// CounterWindowSize gets total windows size
 func (m *RTMetrics) CounterWindowSize() time.Duration {
 	return m.total.WindowSize()
 }
 
-// GetNetworkErrorRatio calculates the amont of network errors such as time outs and dropped connection
+// NetworkErrorRatio calculates the amont of network errors such as time outs and dropped connection
 // that occurred in the given time window compared to the total requests count.
 func (m *RTMetrics) NetworkErrorRatio() float64 {
 	if m.total.Count() == 0 {
@@ -143,7 +152,7 @@ func (m *RTMetrics) NetworkErrorRatio() float64 {
 	return float64(m.netErrors.Count()) / float64(m.total.Count())
 }
 
-// GetResponseCodeRatio calculates ratio of count(startA to endA) / count(startB to endB)
+// ResponseCodeRatio calculates ratio of count(startA to endA) / count(startB to endB)
 func (m *RTMetrics) ResponseCodeRatio(startA, endA, startB, endB int) float64 {
 	a := int64(0)
 	b := int64(0)
@@ -163,6 +172,7 @@ func (m *RTMetrics) ResponseCodeRatio(startA, endA, startB, endB int) float64 {
 	return 0
 }
 
+// Append append a metric
 func (m *RTMetrics) Append(other *RTMetrics) error {
 	if m == other {
 		return errors.New("RTMetrics cannot append to self")
@@ -196,6 +206,7 @@ func (m *RTMetrics) Append(other *RTMetrics) error {
 	return m.histogram.Append(copied.histogram)
 }
 
+// Record records a metric
 func (m *RTMetrics) Record(code int, duration time.Duration) {
 	m.total.Inc(1)
 	if code == http.StatusGatewayTimeout || code == http.StatusBadGateway {
@@ -205,17 +216,17 @@ func (m *RTMetrics) Record(code int, duration time.Duration) {
 	m.recordLatency(duration)
 }
 
-// GetTotalCount returns total count of processed requests collected.
+// TotalCount returns total count of processed requests collected.
 func (m *RTMetrics) TotalCount() int64 {
 	return m.total.Count()
 }
 
-// GetNetworkErrorCount returns total count of processed requests observed
+// NetworkErrorCount returns total count of processed requests observed
 func (m *RTMetrics) NetworkErrorCount() int64 {
 	return m.netErrors.Count()
 }
 
-// GetStatusCodesCounts returns map with counts of the response codes
+// StatusCodesCounts returns map with counts of the response codes
 func (m *RTMetrics) StatusCodesCounts() map[int]int64 {
 	sc := make(map[int]int64)
 	m.statusCodesLock.RLock()
@@ -228,13 +239,14 @@ func (m *RTMetrics) StatusCodesCounts() map[int]int64 {
 	return sc
 }
 
-// GetLatencyHistogram computes and returns resulting histogram with latencies observed.
+// LatencyHistogram computes and returns resulting histogram with latencies observed.
 func (m *RTMetrics) LatencyHistogram() (*HDRHistogram, error) {
 	m.histogramLock.Lock()
 	defer m.histogramLock.Unlock()
 	return m.histogram.Merged()
 }
 
+// Reset reset metrics
 func (m *RTMetrics) Reset() {
 	m.statusCodesLock.Lock()
 	defer m.statusCodesLock.Unlock()
@@ -284,7 +296,7 @@ const (
 	counterResolution      = time.Second
 	histMin                = 1
 	histMax                = 3600000000       // 1 hour in microseconds
-	histSignificantFigures = 2                // signigicant figures (1% precision)
+	histSignificantFigures = 2                // significant figures (1% precision)
 	histBuckets            = 6                // number of sub-histograms in a rolling histogram
 	histPeriod             = 10 * time.Second // roll time
 )

--- a/ratelimit/bucket.go
+++ b/ratelimit/bucket.go
@@ -7,6 +7,7 @@ import (
 	"github.com/mailgun/timetools"
 )
 
+// UndefinedDelay  default delay
 const UndefinedDelay = -1
 
 // rate defines token bucket parameters.
@@ -20,7 +21,7 @@ func (r *rate) String() string {
 	return fmt.Sprintf("rate(%v/%v, burst=%v)", r.average, r.period, r.burst)
 }
 
-// Implements token bucket algorithm (http://en.wikipedia.org/wiki/Token_bucket)
+// tokenBucket Implements token bucket algorithm (http://en.wikipedia.org/wiki/Token_bucket)
 type tokenBucket struct {
 	// The time period controlled by the bucket in nanoseconds.
 	period time.Duration
@@ -83,7 +84,7 @@ func (tb *tokenBucket) rollback() {
 	tb.lastConsumed = 0
 }
 
-// Update modifies `average` and `burst` fields of the token bucket according
+// update modifies `average` and `burst` fields of the token bucket according
 // to the provided `Rate`
 func (tb *tokenBucket) update(rate *rate) error {
 	if rate.period != tb.period {

--- a/ratelimit/bucketset.go
+++ b/ratelimit/bucketset.go
@@ -17,7 +17,7 @@ type TokenBucketSet struct {
 	clock     timetools.TimeProvider
 }
 
-// newTokenBucketSet creates a `TokenBucketSet` from the specified `rates`.
+// NewTokenBucketSet creates a `TokenBucketSet` from the specified `rates`.
 func NewTokenBucketSet(rates *RateSet, clock timetools.TimeProvider) *TokenBucketSet {
 	tbs := new(TokenBucketSet)
 	tbs.clock = clock
@@ -55,6 +55,7 @@ func (tbs *TokenBucketSet) Update(rates *RateSet) {
 	}
 }
 
+// Consume consume tokens
 func (tbs *TokenBucketSet) Consume(tokens int64) (time.Duration, error) {
 	var maxDelay time.Duration = UndefinedDelay
 	var firstErr error
@@ -81,6 +82,7 @@ func (tbs *TokenBucketSet) Consume(tokens int64) (time.Duration, error) {
 	return maxDelay, firstErr
 }
 
+// GetMaxPeriod returns the max period
 func (tbs *TokenBucketSet) GetMaxPeriod() time.Duration {
 	return tbs.maxPeriod
 }

--- a/ratelimit/bucketset.go
+++ b/ratelimit/bucketset.go
@@ -5,8 +5,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/mailgun/timetools"
 	"sort"
+
+	"github.com/mailgun/timetools"
 )
 
 // TokenBucketSet represents a set of TokenBucket covering different time periods.
@@ -56,7 +57,7 @@ func (tbs *TokenBucketSet) Update(rates *RateSet) {
 
 func (tbs *TokenBucketSet) Consume(tokens int64) (time.Duration, error) {
 	var maxDelay time.Duration = UndefinedDelay
-	var firstErr error = nil
+	var firstErr error
 	for _, tokenBucket := range tbs.buckets {
 		// We keep calling `Consume` even after a error is returned for one of
 		// buckets because that allows us to simplify the rollback procedure,

--- a/ratelimit/tokenlimiter_test.go
+++ b/ratelimit/tokenlimiter_test.go
@@ -202,7 +202,7 @@ func (s *LimiterSuite) TestExtractRates(c *C) {
 func (s *LimiterSuite) TestBadRateExtractor(c *C) {
 	// Given
 	extractor := func(*http.Request) (*RateSet, error) {
-		return nil, fmt.Errorf("Boom!")
+		return nil, fmt.Errorf("boom")
 	}
 	rates := NewRateSet()
 	rates.Add(time.Second, 1, 1)

--- a/roundrobin/RequestRewriteListener.go
+++ b/roundrobin/RequestRewriteListener.go
@@ -2,4 +2,5 @@ package roundrobin
 
 import "net/http"
 
+// RequestRewriteListener function to rewrite request
 type RequestRewriteListener func(oldReq *http.Request, newReq *http.Request)

--- a/roundrobin/rebalancer.go
+++ b/roundrobin/rebalancer.go
@@ -16,13 +16,14 @@ import (
 // RebalancerOption - functional option setter for rebalancer
 type RebalancerOption func(*Rebalancer) error
 
-// Meter measures server peformance and returns it's relative value via rating
+// Meter measures server performance and returns it's relative value via rating
 type Meter interface {
 	Rating() float64
 	Record(int, time.Duration)
 	IsReady() bool
 }
 
+// NewMeterFn type of functions to create new Meter
 type NewMeterFn func() (Meter, error)
 
 // Rebalancer increases weights on servers that perform better than others. It also rolls back to original weights
@@ -56,6 +57,7 @@ type Rebalancer struct {
 	log *log.Logger
 }
 
+// RebalancerClock sets a clock
 func RebalancerClock(clock timetools.TimeProvider) RebalancerOption {
 	return func(r *Rebalancer) error {
 		r.clock = clock
@@ -63,6 +65,7 @@ func RebalancerClock(clock timetools.TimeProvider) RebalancerOption {
 	}
 }
 
+// RebalancerBackoff sets a beck off duration
 func RebalancerBackoff(d time.Duration) RebalancerOption {
 	return func(r *Rebalancer) error {
 		r.backoffDuration = d
@@ -70,6 +73,7 @@ func RebalancerBackoff(d time.Duration) RebalancerOption {
 	}
 }
 
+// RebalancerMeter sets a Meter builder function
 func RebalancerMeter(newMeter NewMeterFn) RebalancerOption {
 	return func(r *Rebalancer) error {
 		r.newMeter = newMeter
@@ -85,6 +89,7 @@ func RebalancerErrorHandler(h utils.ErrorHandler) RebalancerOption {
 	}
 }
 
+// RebalancerStickySession sets a sticky session
 func RebalancerStickySession(stickySession *StickySession) RebalancerOption {
 	return func(r *Rebalancer) error {
 		r.stickySession = stickySession
@@ -92,7 +97,7 @@ func RebalancerStickySession(stickySession *StickySession) RebalancerOption {
 	}
 }
 
-// RebalancerErrorHandler is a functional argument that sets error handler of the server
+// RebalancerRequestRewriteListener is a functional argument that sets error handler of the server
 func RebalancerRequestRewriteListener(rrl RequestRewriteListener) RebalancerOption {
 	return func(r *Rebalancer) error {
 		r.requestRewriteListener = rrl
@@ -100,6 +105,7 @@ func RebalancerRequestRewriteListener(rrl RequestRewriteListener) RebalancerOpti
 	}
 }
 
+// NewRebalancer creates a new Rebalancer
 func NewRebalancer(handler balancerHandler, opts ...RebalancerOption) (*Rebalancer, error) {
 	rb := &Rebalancer{
 		mtx:           &sync.Mutex{},
@@ -138,7 +144,7 @@ func NewRebalancer(handler balancerHandler, opts ...RebalancerOption) (*Rebalanc
 	return rb, nil
 }
 
-// Logger defines the logger the rebalancer will use.
+// RebalancerLogger defines the logger the rebalancer will use.
 //
 // It defaults to logrus.StandardLogger(), the global logger used by logrus.
 func RebalancerLogger(l *log.Logger) RebalancerOption {
@@ -148,6 +154,7 @@ func RebalancerLogger(l *log.Logger) RebalancerOption {
 	}
 }
 
+// Servers gets all servers
 func (rb *Rebalancer) Servers() []*url.URL {
 	rb.mtx.Lock()
 	defer rb.mtx.Unlock()
@@ -190,7 +197,7 @@ func (rb *Rebalancer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		}
 
 		if log.GetLevel() >= log.DebugLevel {
-			//log which backend URL we're sending this request to
+			// log which backend URL we're sending this request to
 			log.WithFields(log.Fields{"Request": utils.DumpHttpRequest(req), "ForwardURL": url}).Debugf("vulcand/oxy/roundrobin/rebalancer: Forwarding this request to URL")
 		}
 
@@ -201,7 +208,7 @@ func (rb *Rebalancer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		newReq.URL = url
 	}
 
-	//Emit event to a listener if one exists
+	// Emit event to a listener if one exists
 	if rb.requestRewriteListener != nil {
 		rb.requestRewriteListener(req, &newReq)
 	}
@@ -229,6 +236,7 @@ func (rb *Rebalancer) reset() {
 	rb.ratings = make([]float64, len(rb.servers))
 }
 
+// Wrap sets the next handler to be called by rebalancer handler.
 func (rb *Rebalancer) Wrap(next balancerHandler) error {
 	if rb.next != nil {
 		return fmt.Errorf("already bound to %T", rb.next)
@@ -237,6 +245,7 @@ func (rb *Rebalancer) Wrap(next balancerHandler) error {
 	return nil
 }
 
+// UpsertServer upsert a server
 func (rb *Rebalancer) UpsertServer(u *url.URL, options ...ServerOption) error {
 	rb.mtx.Lock()
 	defer rb.mtx.Unlock()
@@ -253,6 +262,7 @@ func (rb *Rebalancer) UpsertServer(u *url.URL, options ...ServerOption) error {
 	return nil
 }
 
+// RemoveServer remove a server
 func (rb *Rebalancer) RemoveServer(u *url.URL) error {
 	rb.mtx.Lock()
 	defer rb.mtx.Unlock()
@@ -303,7 +313,7 @@ func (rb *Rebalancer) findServer(u *url.URL) (*rbServer, int) {
 	return nil, -1
 }
 
-// Called on every load balancer ServeHTTP call, returns the suggested weights
+// adjustWeights Called on every load balancer ServeHTTP call, returns the suggested weights
 // on every call, can adjust weights if needed.
 func (rb *Rebalancer) adjustWeights() {
 	rb.mtx.Lock()
@@ -461,9 +471,9 @@ type rbServer struct {
 }
 
 const (
-	// This is the maximum weight that handler will set for the server
+	// FSMMaxWeight is the maximum weight that handler will set for the server
 	FSMMaxWeight = 4096
-	// Multiplier for the server weight
+	// FSMGrowFactor Multiplier for the server weight
 	FSMGrowFactor = 4
 )
 
@@ -473,10 +483,12 @@ type codeMeter struct {
 	codeE int
 }
 
+// Rating gets ratio
 func (n *codeMeter) Rating() float64 {
 	return n.r.Ratio()
 }
 
+// Record records a meter
 func (n *codeMeter) Record(code int, d time.Duration) {
 	if code >= n.codeS && code < n.codeE {
 		n.r.IncA(1)
@@ -485,6 +497,7 @@ func (n *codeMeter) Record(code int, d time.Duration) {
 	}
 }
 
+// IsReady returns true if the counter is ready
 func (n *codeMeter) IsReady() bool {
 	return n.r.IsReady()
 }

--- a/roundrobin/rebalancer.go
+++ b/roundrobin/rebalancer.go
@@ -447,9 +447,8 @@ func decrease(target, current int) int {
 	adjusted := current / FSMGrowFactor
 	if adjusted < target {
 		return target
-	} else {
-		return adjusted
 	}
+	return adjusted
 }
 
 // rebalancer server record that keeps track of the original weight supplied by user

--- a/roundrobin/rebalancer_test.go
+++ b/roundrobin/rebalancer_test.go
@@ -114,7 +114,7 @@ func (s *RBSuite) TestRebalancerRecovery(c *C) {
 	proxy := httptest.NewServer(rb)
 	defer proxy.Close()
 
-	for i := 0; i < 6; i += 1 {
+	for i := 0; i < 6; i++ {
 		testutils.Get(proxy.URL)
 		testutils.Get(proxy.URL)
 		s.clock.CurrentTime = s.clock.CurrentTime.Add(rb.backoffDuration + time.Second)
@@ -129,7 +129,7 @@ func (s *RBSuite) TestRebalancerRecovery(c *C) {
 	// server a is now recovering, the weights should go back to the original state
 	rb.servers[0].meter.(*testMeter).rating = 0
 
-	for i := 0; i < 6; i += 1 {
+	for i := 0; i < 6; i++ {
 		testutils.Get(proxy.URL)
 		testutils.Get(proxy.URL)
 		s.clock.CurrentTime = s.clock.CurrentTime.Add(rb.backoffDuration + time.Second)
@@ -170,7 +170,7 @@ func (s *RBSuite) TestRebalancerCascading(c *C) {
 	proxy := httptest.NewServer(rb)
 	defer proxy.Close()
 
-	for i := 0; i < 6; i += 1 {
+	for i := 0; i < 6; i++ {
 		testutils.Get(proxy.URL)
 		testutils.Get(proxy.URL)
 		s.clock.CurrentTime = s.clock.CurrentTime.Add(rb.backoffDuration + time.Second)
@@ -186,7 +186,7 @@ func (s *RBSuite) TestRebalancerCascading(c *C) {
 	rb.servers[1].meter.(*testMeter).rating = 0.2
 	rb.servers[2].meter.(*testMeter).rating = 0.2
 
-	for i := 0; i < 6; i += 1 {
+	for i := 0; i < 6; i++ {
 		testutils.Get(proxy.URL)
 		testutils.Get(proxy.URL)
 		s.clock.CurrentTime = s.clock.CurrentTime.Add(rb.backoffDuration + time.Second)
@@ -227,7 +227,7 @@ func (s *RBSuite) TestRebalancerAllBad(c *C) {
 	proxy := httptest.NewServer(rb)
 	defer proxy.Close()
 
-	for i := 0; i < 6; i += 1 {
+	for i := 0; i < 6; i++ {
 		testutils.Get(proxy.URL)
 		testutils.Get(proxy.URL)
 		s.clock.CurrentTime = s.clock.CurrentTime.Add(rb.backoffDuration + time.Second)
@@ -268,7 +268,7 @@ func (s *RBSuite) TestRebalancerReset(c *C) {
 	proxy := httptest.NewServer(rb)
 	defer proxy.Close()
 
-	for i := 0; i < 6; i += 1 {
+	for i := 0; i < 6; i++ {
 		testutils.Get(proxy.URL)
 		testutils.Get(proxy.URL)
 		s.clock.CurrentTime = s.clock.CurrentTime.Add(rb.backoffDuration + time.Second)
@@ -307,7 +307,7 @@ func (s *RBSuite) TestRebalancerLive(c *C) {
 	proxy := httptest.NewServer(rb)
 	defer proxy.Close()
 
-	for i := 0; i < 1000; i += 1 {
+	for i := 0; i < 1000; i++ {
 		testutils.Get(proxy.URL)
 		if i%10 == 0 {
 			s.clock.CurrentTime = s.clock.CurrentTime.Add(rb.backoffDuration + time.Second)

--- a/roundrobin/stickysessions.go
+++ b/roundrobin/stickysessions.go
@@ -1,4 +1,3 @@
-// package stickysession is a mixin for load balancers that implements layer 7 (http cookie) session affinity
 package roundrobin
 
 import (
@@ -6,10 +5,12 @@ import (
 	"net/url"
 )
 
+// StickySession is a mixin for load balancers that implements layer 7 (http cookie) session affinity
 type StickySession struct {
 	cookieName string
 }
 
+// NewStickySession creates a new StickySession
 func NewStickySession(cookieName string) *StickySession {
 	return &StickySession{cookieName}
 }
@@ -36,6 +37,7 @@ func (s *StickySession) GetBackend(req *http.Request, servers []*url.URL) (*url.
 	return nil, false, nil
 }
 
+// StickBackend creates and sets the cookie
 func (s *StickySession) StickBackend(backend *url.URL, w *http.ResponseWriter) {
 	cookie := &http.Cookie{Name: s.cookieName, Value: backend.String(), Path: "/"}
 	http.SetCookie(*w, cookie)

--- a/roundrobin/stickysessions.go
+++ b/roundrobin/stickysessions.go
@@ -32,9 +32,8 @@ func (s *StickySession) GetBackend(req *http.Request, servers []*url.URL) (*url.
 
 	if s.isBackendAlive(serverURL, servers) {
 		return serverURL, true, nil
-	} else {
-		return nil, false, nil
 	}
+	return nil, false, nil
 }
 
 func (s *StickySession) StickBackend(backend *url.URL, w *http.ResponseWriter) {

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -1,5 +1,5 @@
 /*
-package stream provides http.Handler middleware that passes-through the entire request
+Package stream provides http.Handler middleware that passes-through the entire request
 
 Stream works around several limitations caused by buffering implementations, but
 also introduces certain risks.
@@ -39,7 +39,7 @@ import (
 )
 
 const (
-	// No limit by default
+	// DefaultMaxBodyBytes No limit by default
 	DefaultMaxBodyBytes = -1
 )
 

--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -25,9 +25,9 @@ type STSuite struct{}
 
 var _ = Suite(&STSuite{})
 
-type noOpNextHttpHandler struct{}
+type noOpNextHTTPHandler struct{}
 
-func (n noOpNextHttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {}
+func (n noOpNextHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {}
 
 type noOpIoWriter struct{}
 
@@ -328,28 +328,28 @@ func (s *STSuite) TestPreservesTLS(c *C) {
 }
 
 func BenchmarkLoggingDebugLevel(b *testing.B) {
-	streamer, _ := New(noOpNextHttpHandler{})
+	streamer, _ := New(noOpNextHTTPHandler{})
 
 	log.SetLevel(log.DebugLevel)
 	log.SetOutput(&noOpIoWriter{}) //Make sure we don't emit a bunch of stuff on screen
 
 	for i := 0; i < b.N; i++ {
-		heavyServeHttpLoad(streamer)
+		heavyServeHTTPLoad(streamer)
 	}
 }
 
 func BenchmarkLoggingInfoLevel(b *testing.B) {
-	streamer, _ := New(noOpNextHttpHandler{})
+	streamer, _ := New(noOpNextHTTPHandler{})
 
 	log.SetLevel(log.InfoLevel)
 	log.SetOutput(&noOpIoWriter{}) //Make sure we don't emit a bunch of stuff on screen
 
 	for i := 0; i < b.N; i++ {
-		heavyServeHttpLoad(streamer)
+		heavyServeHTTPLoad(streamer)
 	}
 }
 
-func heavyServeHttpLoad(handler http.Handler) {
+func heavyServeHTTPLoad(handler http.Handler) {
 	w := httptest.NewRecorder()
 	r := &http.Request{}
 	handler.ServeHTTP(w, r)

--- a/stream/threshold.go
+++ b/stream/threshold.go
@@ -7,6 +7,7 @@ import (
 	"github.com/vulcand/predicate"
 )
 
+// IsValidExpression check if it's a valid expression
 func IsValidExpression(expr string) bool {
 	_, err := parseExpression(expr)
 	return err == nil

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -12,10 +12,12 @@ import (
 	"github.com/vulcand/oxy/utils"
 )
 
+// NewHandler creates a new Server
 func NewHandler(handler http.HandlerFunc) *httptest.Server {
 	return httptest.NewServer(handler)
 }
 
+// NewResponder creates a new Server with response
 func NewResponder(response string) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(response))
@@ -31,6 +33,7 @@ func ParseURI(uri string) *url.URL {
 	return out
 }
 
+// ReqOpts request options
 type ReqOpts struct {
 	Host    string
 	Method  string
@@ -39,8 +42,10 @@ type ReqOpts struct {
 	Auth    *utils.BasicAuth
 }
 
+// ReqOption request option type
 type ReqOption func(o *ReqOpts) error
 
+// Method sets request method
 func Method(m string) ReqOption {
 	return func(o *ReqOpts) error {
 		o.Method = m
@@ -48,6 +53,7 @@ func Method(m string) ReqOption {
 	}
 }
 
+// Host sets request host
 func Host(h string) ReqOption {
 	return func(o *ReqOpts) error {
 		o.Host = h
@@ -55,6 +61,7 @@ func Host(h string) ReqOption {
 	}
 }
 
+// Body sets request body
 func Body(b string) ReqOption {
 	return func(o *ReqOpts) error {
 		o.Body = b
@@ -62,6 +69,7 @@ func Body(b string) ReqOption {
 	}
 }
 
+// Header sets request header
 func Header(name, val string) ReqOption {
 	return func(o *ReqOpts) error {
 		if o.Headers == nil {
@@ -72,6 +80,7 @@ func Header(name, val string) ReqOption {
 	}
 }
 
+// Headers sets request headers
 func Headers(h http.Header) ReqOption {
 	return func(o *ReqOpts) error {
 		if o.Headers == nil {
@@ -82,6 +91,7 @@ func Headers(h http.Header) ReqOption {
 	}
 }
 
+// BasicAuth sets request basic auth
 func BasicAuth(username, password string) ReqOption {
 	return func(o *ReqOpts) error {
 		o.Auth = &utils.BasicAuth{
@@ -92,6 +102,7 @@ func BasicAuth(username, password string) ReqOption {
 	}
 }
 
+// MakeRequest create and do a request
 func MakeRequest(url string, opts ...ReqOption) (*http.Response, []byte, error) {
 	o := &ReqOpts{}
 	for _, s := range opts {
@@ -142,6 +153,7 @@ func MakeRequest(url string, opts ...ReqOption) (*http.Response, []byte, error) 
 	return response, nil, err
 }
 
+// Get do a GET request
 func Get(url string, opts ...ReqOption) (*http.Response, []byte, error) {
 	opts = append(opts, Method(http.MethodGet))
 	return MakeRequest(url, opts...)

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -147,7 +147,7 @@ type Record struct {
 	Response Response `json:"response"`
 }
 
-// Req contains information about an HTTP request
+// Request contains information about an HTTP request
 type Request struct {
 	Method    string      `json:"method"`            // Method - request method
 	BodyBytes int64       `json:"body_bytes"`        // BodyBytes - size of request body in bytes
@@ -156,7 +156,7 @@ type Request struct {
 	TLS       *TLS        `json:"tls,omitempty"`     // TLS - optional TLS record, will be recorded if it's a TLS connection
 }
 
-// Resp contains information about HTTP response
+// Response contains information about HTTP response
 type Response struct {
 	Code      int         `json:"code"`              // Code - response status code
 	Roundtrip float64     `json:"roundtrip"`         // Roundtrip - round trip time in milliseconds

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -219,11 +219,11 @@ func csToString(cs uint16) string {
 }
 
 func bodyBytes(h http.Header) int64 {
-	len := h.Get("Content-Length")
-	if len == "" {
+	length := h.Get("Content-Length")
+	if length == "" {
 		return 0
 	}
-	bytes, err := strconv.ParseInt(len, 10, 0)
+	bytes, err := strconv.ParseInt(length, 10, 0)
 	if err == nil {
 		return bytes
 	}

--- a/utils/auth.go
+++ b/utils/auth.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 )
 
+// BasicAuth basic auth information
 type BasicAuth struct {
 	Username string
 	Password string
@@ -16,6 +17,7 @@ func (ba *BasicAuth) String() string {
 	return fmt.Sprintf("Basic %s", encoded)
 }
 
+// ParseAuthHeader creates a new BasicAuth from header values
 func ParseAuthHeader(header string) (*BasicAuth, error) {
 	values := strings.Fields(header)
 	if len(values) != 2 {

--- a/utils/dumpreq.go
+++ b/utils/dumpreq.go
@@ -48,13 +48,13 @@ func Clone(r *http.Request) *SerializableHttpRequest {
 }
 
 func (s *SerializableHttpRequest) ToJson() string {
-	if jsonVal, err := json.Marshal(s); err != nil || jsonVal == nil {
-		return fmt.Sprintf("Error marshalling SerializableHttpRequest to json: %s", err.Error())
-	} else {
-		return string(jsonVal)
+	jsonVal, err := json.Marshal(s)
+	if err != nil || jsonVal == nil {
+		return fmt.Sprintf("Error marshalling SerializableHttpRequest to json: %s", err)
 	}
+	return string(jsonVal)
 }
 
 func DumpHttpRequest(req *http.Request) string {
-	return fmt.Sprintf("%v", Clone(req).ToJson())
+	return Clone(req).ToJson()
 }

--- a/utils/dumpreq.go
+++ b/utils/dumpreq.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 )
 
+// SerializableHttpRequest serializable HTTP request
 type SerializableHttpRequest struct {
 	Method           string
 	URL              *url.URL
@@ -28,6 +29,7 @@ type SerializableHttpRequest struct {
 	TLS              *tls.ConnectionState
 }
 
+// Clone clone a request
 func Clone(r *http.Request) *SerializableHttpRequest {
 	if r == nil {
 		return nil
@@ -47,6 +49,7 @@ func Clone(r *http.Request) *SerializableHttpRequest {
 	return rc
 }
 
+// ToJson serializes to JSON
 func (s *SerializableHttpRequest) ToJson() string {
 	jsonVal, err := json.Marshal(s)
 	if err != nil || jsonVal == nil {
@@ -55,6 +58,7 @@ func (s *SerializableHttpRequest) ToJson() string {
 	return string(jsonVal)
 }
 
+// DumpHttpRequest dump a HTTP request to JSON
 func DumpHttpRequest(req *http.Request) string {
 	return Clone(req).ToJson()
 }

--- a/utils/handler.go
+++ b/utils/handler.go
@@ -8,12 +8,15 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// ErrorHandler error handler
 type ErrorHandler interface {
 	ServeHTTP(w http.ResponseWriter, req *http.Request, err error)
 }
 
+// DefaultHandler default error handler
 var DefaultHandler ErrorHandler = &StdHandler{}
 
+// StdHandler Standard error handler
 type StdHandler struct{}
 
 func (e *StdHandler) ServeHTTP(w http.ResponseWriter, req *http.Request, err error) {
@@ -32,6 +35,7 @@ func (e *StdHandler) ServeHTTP(w http.ResponseWriter, req *http.Request, err err
 	log.Debugf("'%d %s' caused by: %v", statusCode, http.StatusText(statusCode), err)
 }
 
+// ErrorHandlerFunc error handler function type
 type ErrorHandlerFunc func(http.ResponseWriter, *http.Request, error)
 
 // ServeHTTP calls f(w, r).

--- a/utils/source.go
+++ b/utils/source.go
@@ -31,17 +31,17 @@ func NewExtractor(variable string) (SourceExtractor, error) {
 	if strings.HasPrefix(variable, "request.header.") {
 		header := strings.TrimPrefix(variable, "request.header.")
 		if len(header) == 0 {
-			return nil, fmt.Errorf("Wrong header: %s", header)
+			return nil, fmt.Errorf("wrong header: %s", header)
 		}
 		return makeHeaderExtractor(header), nil
 	}
-	return nil, fmt.Errorf("Unsupported limiting variable: '%s'", variable)
+	return nil, fmt.Errorf("unsupported limiting variable: '%s'", variable)
 }
 
 func extractClientIP(req *http.Request) (string, int64, error) {
 	vals := strings.SplitN(req.RemoteAddr, ":", 2)
 	if len(vals[0]) == 0 {
-		return "", 0, fmt.Errorf("Failed to parse client IP: %v", req.RemoteAddr)
+		return "", 0, fmt.Errorf("failed to parse client IP: %v", req.RemoteAddr)
 	}
 	return vals[0], 1, nil
 }

--- a/utils/source.go
+++ b/utils/source.go
@@ -6,21 +6,25 @@ import (
 	"strings"
 )
 
-// ExtractSource extracts the source from the request, e.g. that may be client ip, or particular header that
+// SourceExtractor extracts the source from the request, e.g. that may be client ip, or particular header that
 // identifies the source. amount stands for amount of connections the source consumes, usually 1 for connection limiters
 // error should be returned when source can not be identified
 type SourceExtractor interface {
 	Extract(req *http.Request) (token string, amount int64, err error)
 }
 
+// ExtractorFunc extractor function type
 type ExtractorFunc func(req *http.Request) (token string, amount int64, err error)
 
+// Extract extract from request
 func (f ExtractorFunc) Extract(req *http.Request) (string, int64, error) {
 	return f(req)
 }
 
+// ExtractSource extract source function type
 type ExtractSource func(req *http.Request)
 
+// NewExtractor creates a new SourceExtractor
 func NewExtractor(variable string) (SourceExtractor, error) {
 	if variable == "client.ip" {
 		return ExtractorFunc(extractClientIP), nil


### PR DESCRIPTION
There are still 38 problems that can not be corrected without being breaking

```
buffer/buffer.go:108:28: exported func Logger returns unexported type buffer.optSetter, which can be annoying to use
buffer/buffer.go:119:51: exported func CondSetter returns unexported type buffer.optSetter, which can be annoying to use
buffer/buffer.go:140:30: exported func Retry returns unexported type buffer.optSetter, which can be annoying to use
buffer/buffer.go:152:41: exported func ErrorHandler returns unexported type buffer.optSetter, which can be annoying to use
buffer/buffer.go:160:35: exported func MaxRequestBodyBytes returns unexported type buffer.optSetter, which can be annoying to use
buffer/buffer.go:172:35: exported func MemRequestBodyBytes returns unexported type buffer.optSetter, which can be annoying to use
buffer/buffer.go:183:36: exported func MaxResponseBodyBytes returns unexported type buffer.optSetter, which can be annoying to use
buffer/buffer.go:195:36: exported func MemResponseBodyBytes returns unexported type buffer.optSetter, which can be annoying to use
connlimit/connlimit.go:144:6: type name will be used as connlimit.ConnLimitOption by other packages, and that stutters; consider calling this Option
forward/fwd.go:46:29: exported func PassHostHeader returns unexported type forward.optSetter, which can be annoying to use
forward/fwd.go:55:40: exported func RoundTripper returns unexported type forward.optSetter, which can be annoying to use
forward/fwd.go:63:30: exported func Rewriter returns unexported type forward.optSetter, which can be annoying to use
forward/fwd.go:71:48: exported func WebsocketTLSClientConfig returns unexported type forward.optSetter, which can be annoying to use
forward/fwd.go:79:41: exported func ErrorHandler returns unexported type forward.optSetter, which can be annoying to use
forward/fwd.go:87:43: exported func BufferPool returns unexported type forward.optSetter, which can be annoying to use
forward/fwd.go:95:26: exported func Stream returns unexported type forward.optSetter, which can be annoying to use
forward/fwd.go:105:32: exported func Logger returns unexported type forward.optSetter, which can be annoying to use
forward/fwd.go:122:62: exported func StateListener returns unexported type forward.optSetter, which can be annoying to use
forward/fwd.go:130:68: exported func ResponseModifier returns unexported type forward.optSetter, which can be annoying to use
forward/fwd.go:138:58: exported func StreamingFlushInterval returns unexported type forward.optSetter, which can be annoying to use
forward/fwd.go:203:6: type UrlForwardingStateListener should be URLForwardingStateListener
forward/fwd.go:273:25: method getUrlFromRequest should be getURLFromRequest
forward/fwd_test.go:341:29: should not use basic type string as key in context.WithValue
forward/headers.go:10:2: const XRealIp should be XRealIP
memmetrics/counter.go:13:45: exported func CounterClock returns unexported type memmetrics.rcOptSetter, which can be annoying to use
memmetrics/histogram.go:85:49: exported func RollingClock returns unexported type memmetrics.rhOptSetter, which can be annoying to use
memmetrics/ratio.go:12:47: exported func RatioClock returns unexported type memmetrics.ratioOptSetter, which can be annoying to use
memmetrics/roundtrip.go:42:34: exported func RTCounter returns unexported type memmetrics.rrOptSetter, which can be annoying to use
memmetrics/roundtrip.go:50:44: exported func RTHistogram returns unexported type memmetrics.rrOptSetter, which can be annoying to use
memmetrics/roundtrip.go:58:44: exported func RTClock returns unexported type memmetrics.rrOptSetter, which can be annoying to use
roundrobin/rebalancer.go:180:3: var cookieUrl should be cookieURL
roundrobin/rr.go:42:6: func name will be used as roundrobin.RoundRobinRequestRewriteListener by other packages, and that stutters; consider calling this RequestRewriteListener
roundrobin/rr.go:89:6: func name will be used as roundrobin.RoundRobinLogger by other packages, and that stutters; consider calling this Logger
stream/stream.go:83:28: exported func Logger returns unexported type stream.optSetter, which can be annoying to use
utils/dumpreq.go:13:6: type SerializableHttpRequest should be SerializableHTTPRequest
utils/dumpreq.go:53:35: method ToJson should be ToJSON
utils/dumpreq.go:62:6: func DumpHttpRequest should be DumpHTTPRequest
utils/dumpreq_test.go:9:6: type DumpHttpReqSuite should be DumpHTTPReqSuite
Found 38 lint suggestions; failing.
```