### PR TITLE
Set ServerName explicitly in TLSConfig to ensure SNI works

### DIFF
--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -131,7 +131,10 @@ func MakeRequest(url string, opts ...ReqOption) (*http.Response, []byte, error) 
 	if strings.HasPrefix(url, "https") {
 		tr = &http.Transport{
 			DisableKeepAlives: true,
-			TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
+			TLSClientConfig:   &tls.Config{
+				InsecureSkipVerify: true,
+				ServerName: request.Host,
+			},
 		}
 	} else {
 		tr = &http.Transport{

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -131,9 +131,9 @@ func MakeRequest(url string, opts ...ReqOption) (*http.Response, []byte, error) 
 	if strings.HasPrefix(url, "https") {
 		tr = &http.Transport{
 			DisableKeepAlives: true,
-			TLSClientConfig:   &tls.Config{
+			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: true,
-				ServerName: request.Host,
+				ServerName:         request.Host,
 			},
 		}
 	} else {


### PR DESCRIPTION
Sometime since I first wrote the ACME (Let's Encrypt) code,
and today, golang needs this extra ServerName to be set explicitly
in the TLSConfig.

This is to avoid domain fronting.

https://github.com/golang/go/issues/22704