### PR TITLE
Migrate from go-check to Testify.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -69,9 +69,12 @@
 
 [[projects]]
   name = "github.com/stretchr/testify"
-  packages = ["assert"]
-  revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
-  version = "v1.1.4"
+  packages = [
+    "assert",
+    "require"
+  ]
+  revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
+  version = "v1.2.2"
 
 [[projects]]
   name = "github.com/vulcand/predicate"
@@ -104,12 +107,6 @@
   revision = "1e2299c37cc91a509f1b12369872d27be0ce98a6"
 
 [[projects]]
-  branch = "v1"
-  name = "gopkg.in/check.v1"
-  packages = ["."]
-  revision = "20d25e2804050c1cd24a7eea1e7a6447dd0e74ec"
-
-[[projects]]
   branch = "v2"
   name = "gopkg.in/mgo.v2"
   packages = [
@@ -121,6 +118,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "13c58913794cb91ced539fc4dcde957f6664b82ed886d245ca769960327f7e7f"
+  inputs-digest = "8365c0bc24ea7e144c8e47dcbfd8e88213516587c1c2b89ddc6fbae5e662ed52"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -20,7 +20,7 @@
 
 [[constraint]]
   name = "github.com/stretchr/testify"
-  version = "1.1.4"
+  version = "1.2.2"
 
 [[constraint]]
   name = "github.com/vulcand/predicate"
@@ -29,10 +29,6 @@
 [[constraint]]
   branch = "master"
   name = "golang.org/x/net"
-
-[[constraint]]
-  branch = "v1"
-  name = "gopkg.in/check.v1"
 
 [[override]]
   branch = "master"

--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -223,7 +223,7 @@ func (b *Buffer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	// Read the body while keeping limits in mind. This reader controls the maximum bytes
 	// to read into memory and disk. This reader returns an error if the total request size exceeds the
-	// prefefined MaxSizeBytes. This can occur if we got chunked request, in this case ContentLength would be set to -1
+	// predefined MaxSizeBytes. This can occur if we got chunked request, in this case ContentLength would be set to -1
 	// and the reader would be unbounded bufio in the http.Server
 	body, err := multibuf.New(req.Body, multibuf.MaxBytes(b.maxRequestBodyBytes), multibuf.MemBytes(b.memRequestBodyBytes))
 	if err != nil || body == nil {

--- a/buffer/retry_test.go
+++ b/buffer/retry_test.go
@@ -3,90 +3,87 @@ package buffer
 import (
 	"net/http"
 	"net/http/httptest"
+	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/vulcand/oxy/forward"
 	"github.com/vulcand/oxy/roundrobin"
 	"github.com/vulcand/oxy/testutils"
-
-	. "gopkg.in/check.v1"
 )
 
-type RTSuite struct{}
-
-var _ = Suite(&RTSuite{})
-
-func (s *RTSuite) TestSuccess(c *C) {
+func TestSuccess(t *testing.T) {
 	srv := testutils.NewHandler(func(w http.ResponseWriter, req *http.Request) {
 		w.Write([]byte("hello"))
 	})
 	defer srv.Close()
 
-	lb, rt := new(c, `IsNetworkError() && Attempts() <= 2`)
+	lb, rt := newBufferMiddleware(t, `IsNetworkError() && Attempts() <= 2`)
 
 	proxy := httptest.NewServer(rt)
 	defer proxy.Close()
 
-	lb.UpsertServer(testutils.ParseURI(srv.URL))
+	require.NoError(t, lb.UpsertServer(testutils.ParseURI(srv.URL)))
 
 	re, body, err := testutils.Get(proxy.URL)
-	c.Assert(err, IsNil)
-	c.Assert(re.StatusCode, Equals, http.StatusOK)
-	c.Assert(string(body), Equals, "hello")
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, re.StatusCode)
+	assert.Equal(t, "hello", string(body))
 }
 
-func (s *RTSuite) TestRetryOnError(c *C) {
+func TestRetryOnError(t *testing.T) {
 	srv := testutils.NewHandler(func(w http.ResponseWriter, req *http.Request) {
 		w.Write([]byte("hello"))
 	})
 	defer srv.Close()
 
-	lb, rt := new(c, `IsNetworkError() && Attempts() <= 2`)
+	lb, rt := newBufferMiddleware(t, `IsNetworkError() && Attempts() <= 2`)
 
 	proxy := httptest.NewServer(rt)
 	defer proxy.Close()
 
-	lb.UpsertServer(testutils.ParseURI("http://localhost:64321"))
-	lb.UpsertServer(testutils.ParseURI(srv.URL))
+	require.NoError(t, lb.UpsertServer(testutils.ParseURI("http://localhost:64321")))
+	require.NoError(t, lb.UpsertServer(testutils.ParseURI(srv.URL)))
 
 	re, body, err := testutils.Get(proxy.URL, testutils.Body("some request parameters"))
-	c.Assert(err, IsNil)
-	c.Assert(re.StatusCode, Equals, http.StatusOK)
-	c.Assert(string(body), Equals, "hello")
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, re.StatusCode)
+	assert.Equal(t, "hello", string(body))
 }
 
-func (s *RTSuite) TestRetryExceedAttempts(c *C) {
+func TestRetryExceedAttempts(t *testing.T) {
 	srv := testutils.NewHandler(func(w http.ResponseWriter, req *http.Request) {
 		w.Write([]byte("hello"))
 	})
 	defer srv.Close()
 
-	lb, rt := new(c, `IsNetworkError() && Attempts() <= 2`)
+	lb, rt := newBufferMiddleware(t, `IsNetworkError() && Attempts() <= 2`)
 
 	proxy := httptest.NewServer(rt)
 	defer proxy.Close()
 
-	lb.UpsertServer(testutils.ParseURI("http://localhost:64321"))
-	lb.UpsertServer(testutils.ParseURI("http://localhost:64322"))
-	lb.UpsertServer(testutils.ParseURI("http://localhost:64323"))
-	lb.UpsertServer(testutils.ParseURI(srv.URL))
+	require.NoError(t, lb.UpsertServer(testutils.ParseURI("http://localhost:64321")))
+	require.NoError(t, lb.UpsertServer(testutils.ParseURI("http://localhost:64322")))
+	require.NoError(t, lb.UpsertServer(testutils.ParseURI("http://localhost:64323")))
+	require.NoError(t, lb.UpsertServer(testutils.ParseURI(srv.URL)))
 
 	re, _, err := testutils.Get(proxy.URL)
-	c.Assert(err, IsNil)
-	c.Assert(re.StatusCode, Equals, http.StatusBadGateway)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadGateway, re.StatusCode)
 }
 
-func new(c *C, p string) (*roundrobin.RoundRobin, *Buffer) {
+func newBufferMiddleware(t *testing.T, p string) (*roundrobin.RoundRobin, *Buffer) {
 	// forwarder will proxy the request to whatever destination
 	fwd, err := forward.New()
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// load balancer will round robin request
 	lb, err := roundrobin.New(fwd)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	// stream handler will forward requests to redirect, make sure it uses files
 	st, err := New(lb, Retry(p), MemRequestBodyBytes(1))
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	return lb, st
 }

--- a/forward/rewrite_test.go
+++ b/forward/rewrite_test.go
@@ -7,11 +7,55 @@ import (
 )
 
 func TestIPv6Fix(t *testing.T) {
-	assert.Equal(t, "", ipv6fix(""))
-	assert.Equal(t, "127.0.0.1", ipv6fix("127.0.0.1"))
-	assert.Equal(t, "10.13.14.15", ipv6fix("10.13.14.15"))
-	assert.Equal(t, "fe80::d806:a55d:eb1b:49cc", ipv6fix(`fe80::d806:a55d:eb1b:49cc%vEthernet (vmxnet3 Ethernet Adapter - Virtual Switch)`))
-	assert.Equal(t, "fe80::1", ipv6fix(`fe80::1`))
-	assert.Equal(t, "2000::", ipv6fix(`2000::`))
-	assert.Equal(t, "2001:3452:4952:2837::", ipv6fix(`2001:3452:4952:2837::`))
+	testCases := []struct {
+		desc     string
+		clientIP string
+		expected string
+	}{
+		{
+			desc:     "empty",
+			clientIP: "",
+			expected: "",
+		},
+		{
+			desc:     "ipv4 localhost",
+			clientIP: "127.0.0.1",
+			expected: "127.0.0.1",
+		},
+		{
+			desc:     "ipv4",
+			clientIP: "10.13.14.15",
+			expected: "10.13.14.15",
+		},
+		{
+			desc:     "ipv6 zone",
+			clientIP: `fe80::d806:a55d:eb1b:49cc%vEthernet (vmxnet3 Ethernet Adapter - Virtual Switch)`,
+			expected: "fe80::d806:a55d:eb1b:49cc",
+		},
+		{
+			desc:     "ipv6 medium",
+			clientIP: `fe80::1`,
+			expected: "fe80::1",
+		},
+		{
+			desc:     "ipv6 small",
+			clientIP: `2000::`,
+			expected: "2000::",
+		},
+		{
+			desc:     "ipv6",
+			clientIP: `2001:3452:4952:2837::`,
+			expected: "2001:3452:4952:2837::",
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			actual := ipv6fix(test.clientIP)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
 }

--- a/memmetrics/counter_test.go
+++ b/memmetrics/counter_test.go
@@ -1,34 +1,32 @@
 package memmetrics
 
 import (
+	"testing"
 	"time"
 
 	"github.com/mailgun/timetools"
-	. "gopkg.in/check.v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-type CounterSuite struct {
-	clock *timetools.FreezedTime
-}
-
-var _ = Suite(&CounterSuite{})
-
-func (s *CounterSuite) SetUpSuite(c *C) {
-	s.clock = &timetools.FreezedTime{
+func TestCloneExpired(t *testing.T) {
+	clockTest := &timetools.FreezedTime{
 		CurrentTime: time.Date(2012, 3, 4, 5, 6, 7, 0, time.UTC),
 	}
-}
 
-func (s *CounterSuite) TestCloneExpired(c *C) {
-	cnt, err := NewCounter(3, time.Second, CounterClock(s.clock))
-	c.Assert(err, IsNil)
-	cnt.Inc(1)
-	s.clock.Sleep(time.Second)
-	cnt.Inc(1)
-	s.clock.Sleep(time.Second)
-	cnt.Inc(1)
-	s.clock.Sleep(time.Second)
+	cnt, err := NewCounter(3, time.Second, CounterClock(clockTest))
+	require.NoError(t, err)
 
+	cnt.Inc(1)
+
+	clockTest.Sleep(time.Second)
+	cnt.Inc(1)
+
+	clockTest.Sleep(time.Second)
+	cnt.Inc(1)
+
+	clockTest.Sleep(time.Second)
 	out := cnt.Clone()
-	c.Assert(out.Count(), Equals, int64(2))
+
+	assert.EqualValues(t, 2, out.Count())
 }

--- a/memmetrics/ratio_test.go
+++ b/memmetrics/ratio_test.go
@@ -4,167 +4,165 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mailgun/timetools"
-	. "gopkg.in/check.v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vulcand/oxy/testutils"
 )
 
-func TestFailrate(t *testing.T) { TestingT(t) }
+func TestNewRatioCounterInvalidParams(t *testing.T) {
+	clock := testutils.GetClock()
 
-type FailRateSuite struct {
-	tm *timetools.FreezedTime
-}
-
-var _ = Suite(&FailRateSuite{})
-
-func (s *FailRateSuite) SetUpSuite(c *C) {
-	s.tm = &timetools.FreezedTime{
-		CurrentTime: time.Date(2012, 3, 4, 5, 6, 7, 0, time.UTC),
-	}
-}
-
-func (s *FailRateSuite) TestInvalidParams(c *C) {
 	// Bad buckets count
-	_, err := NewRatioCounter(0, time.Second, RatioClock(s.tm))
-	c.Assert(err, Not(IsNil))
+	_, err := NewRatioCounter(0, time.Second, RatioClock(clock))
+	require.Error(t, err)
 
 	// Too precise resolution
-	_, err = NewRatioCounter(10, time.Millisecond, RatioClock(s.tm))
-	c.Assert(err, Not(IsNil))
+	_, err = NewRatioCounter(10, time.Millisecond, RatioClock(clock))
+	require.Error(t, err)
 }
 
-func (s *FailRateSuite) TestNotReady(c *C) {
+func TestNotReady(t *testing.T) {
+	clock := testutils.GetClock()
+
 	// No data
-	fr, err := NewRatioCounter(10, time.Second, RatioClock(s.tm))
-	c.Assert(err, IsNil)
-	c.Assert(fr.IsReady(), Equals, false)
-	c.Assert(fr.Ratio(), Equals, 0.0)
+	fr, err := NewRatioCounter(10, time.Second, RatioClock(clock))
+	require.NoError(t, err)
+	assert.Equal(t, false, fr.IsReady())
+	assert.Equal(t, 0.0, fr.Ratio())
 
 	// Not enough data
-	fr, err = NewRatioCounter(10, time.Second, RatioClock(s.tm))
-	c.Assert(err, IsNil)
+	fr, err = NewRatioCounter(10, time.Second, RatioClock(clock))
+	require.NoError(t, err)
 	fr.CountA()
-	c.Assert(fr.IsReady(), Equals, false)
+	assert.Equal(t, false, fr.IsReady())
 }
 
-func (s *FailRateSuite) TestNoB(c *C) {
-	fr, err := NewRatioCounter(1, time.Second, RatioClock(s.tm))
-	c.Assert(err, IsNil)
+func TestNoB(t *testing.T) {
+	fr, err := NewRatioCounter(1, time.Second, RatioClock(testutils.GetClock()))
+	require.NoError(t, err)
 	fr.IncA(1)
-	c.Assert(fr.IsReady(), Equals, true)
-	c.Assert(fr.Ratio(), Equals, 1.0)
+	assert.Equal(t, true, fr.IsReady())
+	assert.Equal(t, 1.0, fr.Ratio())
 }
 
-func (s *FailRateSuite) TestNoA(c *C) {
-	fr, err := NewRatioCounter(1, time.Second, RatioClock(s.tm))
-	c.Assert(err, IsNil)
+func TestNoA(t *testing.T) {
+	fr, err := NewRatioCounter(1, time.Second, RatioClock(testutils.GetClock()))
+	require.NoError(t, err)
 	fr.IncB(1)
-	c.Assert(fr.IsReady(), Equals, true)
-	c.Assert(fr.Ratio(), Equals, 0.0)
+	assert.Equal(t, true, fr.IsReady())
+	assert.Equal(t, 0.0, fr.Ratio())
 }
 
 // Make sure that data is properly calculated over several buckets
-func (s *FailRateSuite) TestMultipleBuckets(c *C) {
-	fr, err := NewRatioCounter(3, time.Second, RatioClock(s.tm))
-	c.Assert(err, IsNil)
+func TestMultipleBuckets(t *testing.T) {
+	clock := testutils.GetClock()
+
+	fr, err := NewRatioCounter(3, time.Second, RatioClock(clock))
+	require.NoError(t, err)
 
 	fr.IncB(1)
-	s.tm.CurrentTime = s.tm.CurrentTime.Add(time.Second)
+	clock.CurrentTime = clock.CurrentTime.Add(time.Second)
 	fr.IncA(1)
 
-	s.tm.CurrentTime = s.tm.CurrentTime.Add(time.Second)
+	clock.CurrentTime = clock.CurrentTime.Add(time.Second)
 	fr.IncA(1)
 
-	c.Assert(fr.IsReady(), Equals, true)
-	c.Assert(fr.Ratio(), Equals, float64(2)/float64(3))
+	assert.Equal(t, true, fr.IsReady())
+	assert.Equal(t, float64(2)/float64(3), fr.Ratio())
 }
 
 // Make sure that data is properly calculated over several buckets
 // When we overwrite old data when the window is rolling
-func (s *FailRateSuite) TestOverwriteBuckets(c *C) {
-	fr, err := NewRatioCounter(3, time.Second, RatioClock(s.tm))
-	c.Assert(err, IsNil)
+func TestOverwriteBuckets(t *testing.T) {
+	clock := testutils.GetClock()
+
+	fr, err := NewRatioCounter(3, time.Second, RatioClock(clock))
+	require.NoError(t, err)
 
 	fr.IncB(1)
 
-	s.tm.CurrentTime = s.tm.CurrentTime.Add(time.Second)
+	clock.CurrentTime = clock.CurrentTime.Add(time.Second)
 	fr.IncA(1)
 
-	s.tm.CurrentTime = s.tm.CurrentTime.Add(time.Second)
+	clock.CurrentTime = clock.CurrentTime.Add(time.Second)
 	fr.IncA(1)
 
 	// This time we should overwrite the old data points
-	s.tm.CurrentTime = s.tm.CurrentTime.Add(time.Second)
+	clock.CurrentTime = clock.CurrentTime.Add(time.Second)
 	fr.IncA(1)
 	fr.IncB(2)
 
-	c.Assert(fr.IsReady(), Equals, true)
-	c.Assert(fr.Ratio(), Equals, float64(3)/float64(5))
+	assert.Equal(t, true, fr.IsReady())
+	assert.Equal(t, float64(3)/float64(5), fr.Ratio())
 }
 
 // Make sure we cleanup the data after periods of inactivity
 // So it does not mess up the stats
-func (s *FailRateSuite) TestInactiveBuckets(c *C) {
+func TestInactiveBuckets(t *testing.T) {
+	clock := testutils.GetClock()
 
-	fr, err := NewRatioCounter(3, time.Second, RatioClock(s.tm))
-	c.Assert(err, IsNil)
+	fr, err := NewRatioCounter(3, time.Second, RatioClock(clock))
+	require.NoError(t, err)
 
 	fr.IncB(1)
 
-	s.tm.CurrentTime = s.tm.CurrentTime.Add(time.Second)
+	clock.CurrentTime = clock.CurrentTime.Add(time.Second)
 	fr.IncA(1)
 
-	s.tm.CurrentTime = s.tm.CurrentTime.Add(time.Second)
+	clock.CurrentTime = clock.CurrentTime.Add(time.Second)
 	fr.IncA(1)
 
 	// This time we should overwrite the old data points with new data
-	s.tm.CurrentTime = s.tm.CurrentTime.Add(time.Second)
+	clock.CurrentTime = clock.CurrentTime.Add(time.Second)
 	fr.IncA(1)
 	fr.IncB(2)
 
 	// Jump to the last bucket and change the data
-	s.tm.CurrentTime = s.tm.CurrentTime.Add(time.Second * 2)
+	clock.CurrentTime = clock.CurrentTime.Add(time.Second * 2)
 	fr.IncB(1)
 
-	c.Assert(fr.IsReady(), Equals, true)
-	c.Assert(fr.Ratio(), Equals, float64(1)/float64(4))
+	assert.Equal(t, true, fr.IsReady())
+	assert.Equal(t, float64(1)/float64(4), fr.Ratio())
 }
 
-func (s *FailRateSuite) TestLongPeriodsOfInactivity(c *C) {
-	fr, err := NewRatioCounter(2, time.Second, RatioClock(s.tm))
-	c.Assert(err, IsNil)
+func TestLongPeriodsOfInactivity(t *testing.T) {
+	clock := testutils.GetClock()
+
+	fr, err := NewRatioCounter(2, time.Second, RatioClock(clock))
+	require.NoError(t, err)
 
 	fr.IncB(1)
 
-	s.tm.CurrentTime = s.tm.CurrentTime.Add(time.Second)
+	clock.CurrentTime = clock.CurrentTime.Add(time.Second)
 	fr.IncA(1)
 
-	c.Assert(fr.IsReady(), Equals, true)
-	c.Assert(fr.Ratio(), Equals, 0.5)
+	assert.Equal(t, true, fr.IsReady())
+	assert.Equal(t, 0.5, fr.Ratio())
 
 	// This time we should overwrite all data points
-	s.tm.CurrentTime = s.tm.CurrentTime.Add(100 * time.Second)
+	clock.CurrentTime = clock.CurrentTime.Add(100 * time.Second)
 	fr.IncA(1)
-	c.Assert(fr.Ratio(), Equals, 1.0)
+	assert.Equal(t, 1.0, fr.Ratio())
 }
 
-func (s *FailRateSuite) TestReset(c *C) {
-	fr, err := NewRatioCounter(1, time.Second, RatioClock(s.tm))
-	c.Assert(err, IsNil)
+func TestNewRatioCounterReset(t *testing.T) {
+	fr, err := NewRatioCounter(1, time.Second, RatioClock(testutils.GetClock()))
+	require.NoError(t, err)
 
 	fr.IncB(1)
 	fr.IncA(1)
 
-	c.Assert(fr.IsReady(), Equals, true)
-	c.Assert(fr.Ratio(), Equals, 0.5)
+	assert.Equal(t, true, fr.IsReady())
+	assert.Equal(t, 0.5, fr.Ratio())
 
 	// Reset the counter
 	fr.Reset()
-	c.Assert(fr.IsReady(), Equals, false)
+	assert.Equal(t, false, fr.IsReady())
 
 	// Now add some stats
 	fr.IncA(2)
 
 	// We are game again!
-	c.Assert(fr.IsReady(), Equals, true)
-	c.Assert(fr.Ratio(), Equals, 1.0)
+	assert.Equal(t, true, fr.IsReady())
+	assert.Equal(t, 1.0, fr.Ratio())
 }

--- a/ratelimit/bucket.go
+++ b/ratelimit/bucket.go
@@ -64,7 +64,7 @@ func (tb *tokenBucket) consume(tokens int64) (time.Duration, error) {
 	tb.updateAvailableTokens()
 	tb.lastConsumed = 0
 	if tokens > tb.burst {
-		return UndefinedDelay, fmt.Errorf("Requested tokens larger than max tokens")
+		return UndefinedDelay, fmt.Errorf("requested tokens larger than max tokens")
 	}
 	if tb.availableTokens < tokens {
 		return tb.timeTillAvailable(tokens), nil
@@ -88,7 +88,7 @@ func (tb *tokenBucket) rollback() {
 // to the provided `Rate`
 func (tb *tokenBucket) update(rate *rate) error {
 	if rate.period != tb.period {
-		return fmt.Errorf("Period mismatch: %v != %v", tb.period, rate.period)
+		return fmt.Errorf("period mismatch: %v != %v", tb.period, rate.period)
 	}
 	tb.timePerToken = time.Duration(int64(tb.period) / rate.average)
 	tb.burst = rate.burst

--- a/ratelimit/bucket_test.go
+++ b/ratelimit/bucket_test.go
@@ -4,298 +4,343 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mailgun/timetools"
-	. "gopkg.in/check.v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vulcand/oxy/testutils"
 )
 
-func TestTokenBucket(t *testing.T) { TestingT(t) }
+func TestConsumeSingleToken(t *testing.T) {
+	clock := testutils.GetClock()
 
-type BucketSuite struct {
-	clock *timetools.FreezedTime
-}
-
-var _ = Suite(&BucketSuite{})
-
-func (s *BucketSuite) SetUpSuite(c *C) {
-	s.clock = &timetools.FreezedTime{
-		CurrentTime: time.Date(2012, 3, 4, 5, 6, 7, 0, time.UTC),
-	}
-}
-
-func (s *BucketSuite) TestConsumeSingleToken(c *C) {
-	tb := newTokenBucket(&rate{time.Second, 1, 1}, s.clock)
+	tb := newTokenBucket(&rate{period: time.Second, average: 1, burst: 1}, clock)
 
 	// First request passes
 	delay, err := tb.consume(1)
-	c.Assert(err, IsNil)
-	c.Assert(delay, Equals, time.Duration(0))
+	require.NoError(t, err)
+	assert.Equal(t, time.Duration(0), delay)
 
 	// Next request does not pass the same second
 	delay, err = tb.consume(1)
-	c.Assert(err, IsNil)
-	c.Assert(delay, Equals, time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, time.Second, delay)
 
 	// Second later, the request passes
-	s.clock.Sleep(time.Second)
+	clock.Sleep(time.Second)
+
 	delay, err = tb.consume(1)
-	c.Assert(err, IsNil)
-	c.Assert(delay, Equals, time.Duration(0))
+	require.NoError(t, err)
+	assert.Equal(t, time.Duration(0), delay)
 
 	// Five seconds later, still only one request is allowed
 	// because maxBurst is 1
-	s.clock.Sleep(5 * time.Second)
+	clock.Sleep(5 * time.Second)
+
 	delay, err = tb.consume(1)
-	c.Assert(err, IsNil)
-	c.Assert(delay, Equals, time.Duration(0))
+	require.NoError(t, err)
+	assert.Equal(t, time.Duration(0), delay)
 
 	// The next one is forbidden
 	delay, err = tb.consume(1)
-	c.Assert(err, IsNil)
-	c.Assert(delay, Equals, time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, time.Second, delay)
 }
 
-func (s *BucketSuite) TestFastConsumption(c *C) {
-	tb := newTokenBucket(&rate{time.Second, 1, 1}, s.clock)
+func TestFastConsumption(t *testing.T) {
+	clock := testutils.GetClock()
+
+	tb := newTokenBucket(&rate{period: time.Second, average: 1, burst: 1}, clock)
 
 	// First request passes
 	delay, err := tb.consume(1)
-	c.Assert(err, IsNil)
-	c.Assert(delay, Equals, time.Duration(0))
+	require.NoError(t, err)
+	assert.Equal(t, time.Duration(0), delay)
 
 	// Try 200 ms later
-	s.clock.Sleep(time.Millisecond * 200)
+	clock.Sleep(time.Millisecond * 200)
+
 	delay, err = tb.consume(1)
-	c.Assert(err, IsNil)
-	c.Assert(delay, Equals, time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, time.Second, delay)
 
 	// Try 700 ms later
-	s.clock.Sleep(time.Millisecond * 700)
+	clock.Sleep(time.Millisecond * 700)
+
 	delay, err = tb.consume(1)
-	c.Assert(err, IsNil)
-	c.Assert(delay, Equals, time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, time.Second, delay)
 
 	// Try 100 ms later, success!
-	s.clock.Sleep(time.Millisecond * 100)
+	clock.Sleep(time.Millisecond * 100)
+
 	delay, err = tb.consume(1)
-	c.Assert(err, IsNil)
-	c.Assert(delay, Equals, time.Duration(0))
+	require.NoError(t, err)
+	assert.Equal(t, time.Duration(0), delay)
 }
 
-func (s *BucketSuite) TestConsumeMultipleTokens(c *C) {
-	tb := newTokenBucket(&rate{time.Second, 3, 5}, s.clock)
+func TestConsumeMultipleTokens(t *testing.T) {
+	tb := newTokenBucket(&rate{period: time.Second, average: 3, burst: 5}, testutils.GetClock())
 
 	delay, err := tb.consume(3)
-	c.Assert(err, IsNil)
-	c.Assert(delay, Equals, time.Duration(0))
+	require.NoError(t, err)
+	assert.Equal(t, time.Duration(0), delay)
 
 	delay, err = tb.consume(2)
-	c.Assert(err, IsNil)
-	c.Assert(delay, Equals, time.Duration(0))
+	require.NoError(t, err)
+	assert.Equal(t, time.Duration(0), delay)
 
 	delay, err = tb.consume(1)
-	c.Assert(err, IsNil)
-	c.Assert(delay, Not(Equals), time.Duration(0))
+	require.NoError(t, err)
+	assert.NotEqual(t, time.Duration(0), delay)
 }
 
-func (s *BucketSuite) TestDelayIsCorrect(c *C) {
-	tb := newTokenBucket(&rate{time.Second, 3, 5}, s.clock)
+func TestDelayIsCorrect(t *testing.T) {
+	clock := testutils.GetClock()
+
+	tb := newTokenBucket(&rate{period: time.Second, average: 3, burst: 5}, clock)
 
 	// Exhaust initial capacity
 	delay, err := tb.consume(5)
-	c.Assert(err, IsNil)
-	c.Assert(delay, Equals, time.Duration(0))
+	require.NoError(t, err)
+	assert.Equal(t, time.Duration(0), delay)
 
 	delay, err = tb.consume(3)
-	c.Assert(err, IsNil)
-	c.Assert(delay, Not(Equals), time.Duration(0))
+	require.NoError(t, err)
+	assert.NotEqual(t, time.Duration(0), delay)
 
 	// Now wait provided delay and make sure we can consume now
-	s.clock.Sleep(delay)
+	clock.Sleep(delay)
+
 	delay, err = tb.consume(3)
-	c.Assert(err, IsNil)
-	c.Assert(delay, Equals, time.Duration(0))
+	require.NoError(t, err)
+	assert.Equal(t, time.Duration(0), delay)
 }
 
 // Make sure requests that exceed burst size are not allowed
-func (s *BucketSuite) TestExceedsBurst(c *C) {
-	tb := newTokenBucket(&rate{time.Second, 1, 10}, s.clock)
+func TestExceedsBurst(t *testing.T) {
+	tb := newTokenBucket(&rate{period: time.Second, average: 1, burst: 10}, testutils.GetClock())
 
 	_, err := tb.consume(11)
-	c.Assert(err, NotNil)
+	require.Error(t, err)
 }
 
-func (s *BucketSuite) TestConsumeBurst(c *C) {
-	tb := newTokenBucket(&rate{time.Second, 2, 5}, s.clock)
+func TestConsumeBurst(t *testing.T) {
+	tb := newTokenBucket(&rate{period: time.Second, average: 2, burst: 5}, testutils.GetClock())
 
 	// In two seconds we would have 5 tokens
-	s.clock.Sleep(2 * time.Second)
+	testutils.GetClock().Sleep(2 * time.Second)
 
 	// Lets consume 5 at once
 	delay, err := tb.consume(5)
-	c.Assert(delay, Equals, time.Duration(0))
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
+	assert.Equal(t, time.Duration(0), delay)
 }
 
-func (s *BucketSuite) TestConsumeEstimate(c *C) {
-	tb := newTokenBucket(&rate{time.Second, 2, 4}, s.clock)
+func TestConsumeEstimate(t *testing.T) {
+	tb := newTokenBucket(&rate{period: time.Second, average: 2, burst: 4}, testutils.GetClock())
 
 	// Consume all burst at once
 	delay, err := tb.consume(4)
-	c.Assert(err, IsNil)
-	c.Assert(delay, Equals, time.Duration(0))
+	require.NoError(t, err)
+	assert.Equal(t, time.Duration(0), delay)
 
 	// Now try to consume it and face delay
 	delay, err = tb.consume(4)
-	c.Assert(err, IsNil)
-	c.Assert(delay, Equals, time.Duration(2)*time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, time.Duration(2)*time.Second, delay)
 }
 
 // If a rate with different period is passed to the `update` method, then an
 // error is returned but the state of the bucket remains valid and unchanged.
-func (s *BucketSuite) TestUpdateInvalidPeriod(c *C) {
+func TestUpdateInvalidPeriod(t *testing.T) {
+	clock := testutils.GetClock()
+
 	// Given
-	tb := newTokenBucket(&rate{time.Second, 10, 20}, s.clock)
-	tb.consume(15) // 5 tokens available
+	tb := newTokenBucket(&rate{period: time.Second, average: 10, burst: 20}, clock)
+	_, err := tb.consume(15) // 5 tokens available
+	require.NoError(t, err)
+
 	// When
-	err := tb.update(&rate{time.Second + 1, 30, 40}) // still 5 tokens available
+	err = tb.update(&rate{period: time.Second + 1, average: 30, burst: 40}) // still 5 tokens available
+	require.Error(t, err)
+
 	// Then
-	c.Assert(err, NotNil)
 
 	// ...check that rate did not change
-	s.clock.Sleep(500 * time.Millisecond)
+	clock.Sleep(500 * time.Millisecond)
+
 	delay, err := tb.consume(11)
-	c.Assert(err, IsNil)
-	c.Assert(delay, Equals, 100*time.Millisecond)
+	require.NoError(t, err)
+	assert.Equal(t, 100*time.Millisecond, delay)
+
 	delay, err = tb.consume(10)
-	c.Assert(err, IsNil)
-	c.Assert(delay, Equals, time.Duration(0)) // 0 available
+	require.NoError(t, err)
+	// 0 available
+	assert.Equal(t, time.Duration(0), delay)
 
 	// ...check that burst did not change
-	s.clock.Sleep(40 * time.Second)
+	clock.Sleep(40 * time.Second)
 	_, err = tb.consume(21)
-	c.Assert(err, NotNil)
+	require.Error(t, err)
+
 	delay, err = tb.consume(20)
-	c.Assert(err, IsNil)
-	c.Assert(delay, Equals, time.Duration(0)) // 0 available
+	require.NoError(t, err)
+	// 0 available
+	assert.Equal(t, time.Duration(0), delay)
 }
 
 // If the capacity of the bucket is increased by the update then it takes some
 // time to fill the bucket with tokens up to the new capacity.
-func (s *BucketSuite) TestUpdateBurstIncreased(c *C) {
+func TestUpdateBurstIncreased(t *testing.T) {
+	clock := testutils.GetClock()
+
 	// Given
-	tb := newTokenBucket(&rate{time.Second, 10, 20}, s.clock)
-	tb.consume(15) // 5 tokens available
+	tb := newTokenBucket(&rate{period: time.Second, average: 10, burst: 20}, clock)
+	_, err := tb.consume(15) // 5 tokens available
+	require.NoError(t, err)
+
 	// When
-	err := tb.update(&rate{time.Second, 10, 50}) // still 5 tokens available
+	err = tb.update(&rate{period: time.Second, average: 10, burst: 50}) // still 5 tokens available
+	require.NoError(t, err)
+
 	// Then
-	c.Assert(err, IsNil)
 	delay, err := tb.consume(50)
-	c.Assert(err, IsNil)
-	c.Assert(delay, Equals, time.Duration(time.Second/10*45))
+	require.NoError(t, err)
+	assert.Equal(t, time.Duration(time.Second/10*45), delay)
 }
 
 // If the capacity of the bucket is increased by the update then it takes some
 // time to fill the bucket with tokens up to the new capacity.
-func (s *BucketSuite) TestUpdateBurstDecreased(c *C) {
+func TestUpdateBurstDecreased(t *testing.T) {
+	clock := testutils.GetClock()
+
 	// Given
-	tb := newTokenBucket(&rate{time.Second, 10, 50}, s.clock)
-	tb.consume(15) // 35 tokens available
+	tb := newTokenBucket(&rate{period: time.Second, average: 10, burst: 50}, clock)
+	_, err := tb.consume(15) // 35 tokens available
+	require.NoError(t, err)
+
 	// When
-	err := tb.update(&rate{time.Second, 10, 20}) // the number of available tokens reduced to 20.
+	err = tb.update(&rate{period: time.Second, average: 10, burst: 20}) // the number of available tokens reduced to 20.
+	require.NoError(t, err)
+
 	// Then
-	c.Assert(err, IsNil)
 	delay, err := tb.consume(21)
-	c.Assert(err, NotNil)
-	c.Assert(delay, Equals, time.Duration(-1))
+	require.Error(t, err)
+	assert.Equal(t, time.Duration(-1), delay)
 }
 
 // If rate is updated then it affects the bucket refill speed.
-func (s *BucketSuite) TestUpdateRateChanged(c *C) {
+func TestUpdateRateChanged(t *testing.T) {
+	clock := testutils.GetClock()
+
 	// Given
-	tb := newTokenBucket(&rate{time.Second, 10, 20}, s.clock)
-	tb.consume(15) // 5 tokens available
+	tb := newTokenBucket(&rate{period: time.Second, average: 10, burst: 20}, clock)
+	_, err := tb.consume(15) // 5 tokens available
+	require.NoError(t, err)
+
 	// When
-	err := tb.update(&rate{time.Second, 20, 20}) // still 5 tokens available
-	c.Assert(err, IsNil)
+	err = tb.update(&rate{period: time.Second, average: 20, burst: 20}) // still 5 tokens available
+	require.NoError(t, err)
+
 	// Then
 	delay, err := tb.consume(20)
-	c.Assert(err, IsNil)
-	c.Assert(delay, Equals, time.Duration(time.Second/20*15))
+	require.NoError(t, err)
+	assert.Equal(t, time.Duration(time.Second/20*15), delay)
 }
 
 // Only the most recent consumption is reverted by `Rollback`.
-func (s *BucketSuite) TestRollback(c *C) {
+func TestRollback(t *testing.T) {
+	clock := testutils.GetClock()
+
 	// Given
-	tb := newTokenBucket(&rate{time.Second, 10, 20}, s.clock)
-	tb.consume(8) // 12 tokens available
-	tb.consume(7) // 5 tokens available
+	tb := newTokenBucket(&rate{period: time.Second, average: 10, burst: 20}, clock)
+	_, err := tb.consume(8) // 12 tokens available
+	require.NoError(t, err)
+	_, err = tb.consume(7) // 5 tokens available
+	require.NoError(t, err)
+
 	// When
 	tb.rollback() // 12 tokens available
+
 	// Then
 	delay, err := tb.consume(12)
-	c.Assert(err, IsNil)
-	c.Assert(delay, Equals, time.Duration(0))
+	require.NoError(t, err)
+	assert.Equal(t, time.Duration(0), delay)
+
 	delay, err = tb.consume(1)
-	c.Assert(err, IsNil)
-	c.Assert(delay, Equals, 100*time.Millisecond)
+	require.NoError(t, err)
+	assert.Equal(t, 100*time.Millisecond, delay)
 }
 
 // It is safe to call `Rollback` several times. The second and all subsequent
 // calls just do nothing.
-func (s *BucketSuite) TestRollbackSeveralTimes(c *C) {
+func TestRollbackSeveralTimes(t *testing.T) {
 	// Given
-	tb := newTokenBucket(&rate{time.Second, 10, 20}, s.clock)
-	tb.consume(8) // 12 tokens available
+	tb := newTokenBucket(&rate{period: time.Second, average: 10, burst: 20}, testutils.GetClock())
+	_, err := tb.consume(8) // 12 tokens available
+	require.NoError(t, err)
 	tb.rollback() // 20 tokens available
+
 	// When
 	tb.rollback() // still 20 tokens available
 	tb.rollback() // still 20 tokens available
 	tb.rollback() // still 20 tokens available
+
 	// Then: all 20 tokens can be consumed
 	delay, err := tb.consume(20)
-	c.Assert(err, IsNil)
-	c.Assert(delay, Equals, time.Duration(0))
+	require.NoError(t, err)
+	assert.Equal(t, time.Duration(0), delay)
+
 	delay, err = tb.consume(1)
-	c.Assert(err, IsNil)
-	c.Assert(delay, Equals, 100*time.Millisecond)
+	require.NoError(t, err)
+	assert.Equal(t, 100*time.Millisecond, delay)
 }
 
 // If previous consumption returned a delay due to an attempt to consume more
 // tokens then there are available, then `Rollback` has no effect.
-func (s *BucketSuite) TestRollbackAfterAvailableExceeded(c *C) {
+func TestRollbackAfterAvailableExceeded(t *testing.T) {
 	// Given
-	tb := newTokenBucket(&rate{time.Second, 10, 20}, s.clock)
-	tb.consume(8)                // 12 tokens available
+	tb := newTokenBucket(&rate{period: time.Second, average: 10, burst: 20}, testutils.GetClock())
+	_, err := tb.consume(8) // 12 tokens available
+	require.NoError(t, err)
 	delay, err := tb.consume(15) // still 12 tokens available
-	c.Assert(err, IsNil)
-	c.Assert(delay, Equals, 300*time.Millisecond)
+	require.NoError(t, err)
+	assert.Equal(t, 300*time.Millisecond, delay)
+
 	// When
 	tb.rollback() // Previous operation consumed 0 tokens, so rollback has no effect.
+
 	// Then
 	delay, err = tb.consume(12)
-	c.Assert(err, IsNil)
-	c.Assert(delay, Equals, time.Duration(0))
+	require.NoError(t, err)
+	assert.Equal(t, time.Duration(0), delay)
+
 	delay, err = tb.consume(1)
-	c.Assert(err, IsNil)
-	c.Assert(delay, Equals, 100*time.Millisecond)
+	require.NoError(t, err)
+	assert.Equal(t, 100*time.Millisecond, delay)
 }
 
 // If previous consumption returned a error due to an attempt to consume more
 // tokens then the bucket's burst size, then `Rollback` has no effect.
-func (s *BucketSuite) TestRollbackAfterError(c *C) {
+func TestRollbackAfterError(t *testing.T) {
+	clock := testutils.GetClock()
+
 	// Given
-	tb := newTokenBucket(&rate{time.Second, 10, 20}, s.clock)
-	tb.consume(8)                // 12 tokens available
+	tb := newTokenBucket(&rate{period: time.Second, average: 10, burst: 20}, clock)
+	_, err := tb.consume(8) // 12 tokens available
+	require.NoError(t, err)
 	delay, err := tb.consume(21) // still 12 tokens available
-	c.Assert(err, NotNil)
-	c.Assert(delay, Equals, time.Duration(-1))
+	require.Error(t, err)
+	assert.Equal(t, time.Duration(-1), delay)
+
 	// When
 	tb.rollback() // Previous operation consumed 0 tokens, so rollback has no effect.
+
 	// Then
 	delay, err = tb.consume(12)
-	c.Assert(err, IsNil)
-	c.Assert(delay, Equals, time.Duration(0))
+	require.NoError(t, err)
+	assert.Equal(t, time.Duration(0), delay)
+
 	delay, err = tb.consume(1)
-	c.Assert(err, IsNil)
-	c.Assert(delay, Equals, 100*time.Millisecond)
+	require.NoError(t, err)
+	assert.Equal(t, 100*time.Millisecond, delay)
 }

--- a/ratelimit/bucketset.go
+++ b/ratelimit/bucketset.go
@@ -2,10 +2,9 @@ package ratelimit
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
-
-	"sort"
 
 	"github.com/mailgun/timetools"
 )

--- a/ratelimit/bucketset_test.go
+++ b/ratelimit/bucketset_test.go
@@ -1,185 +1,243 @@
 package ratelimit
 
 import (
+	"testing"
 	"time"
 
-	"github.com/mailgun/timetools"
-	. "gopkg.in/check.v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vulcand/oxy/testutils"
 )
 
-type BucketSetSuite struct {
-	clock *timetools.FreezedTime
-}
-
-var _ = Suite(&BucketSetSuite{})
-
-func (s *BucketSetSuite) SetUpSuite(c *C) {
-	s.clock = &timetools.FreezedTime{
-		CurrentTime: time.Date(2012, 3, 4, 5, 6, 7, 0, time.UTC),
-	}
-}
-
 // A value returned by `MaxPeriod` corresponds to the longest bucket time period.
-func (s *BucketSetSuite) TestLongestPeriod(c *C) {
+func TestLongestPeriod(t *testing.T) {
 	// Given
 	rates := NewRateSet()
-	rates.Add(1*time.Second, 10, 20)
-	rates.Add(7*time.Second, 10, 20)
-	rates.Add(5*time.Second, 11, 21)
+	require.NoError(t, rates.Add(1*time.Second, 10, 20))
+	require.NoError(t, rates.Add(7*time.Second, 10, 20))
+	require.NoError(t, rates.Add(5*time.Second, 11, 21))
+
+	clock := testutils.GetClock()
+
 	// When
-	tbs := NewTokenBucketSet(rates, s.clock)
+	tbs := NewTokenBucketSet(rates, clock)
+
 	// Then
-	c.Assert(tbs.maxPeriod, Equals, 7*time.Second)
+	assert.Equal(t, 7*time.Second, tbs.maxPeriod)
 }
 
 // Successful token consumption updates state of all buckets in the set.
-func (s *BucketSetSuite) TestConsume(c *C) {
+func TestConsume(t *testing.T) {
 	// Given
 	rates := NewRateSet()
-	rates.Add(1*time.Second, 10, 20)
-	rates.Add(10*time.Second, 20, 50)
-	tbs := NewTokenBucketSet(rates, s.clock)
+	require.NoError(t, rates.Add(1*time.Second, 10, 20))
+	require.NoError(t, rates.Add(10*time.Second, 20, 50))
+
+	clock := testutils.GetClock()
+
+	tbs := NewTokenBucketSet(rates, clock)
+
 	// When
 	delay, err := tbs.Consume(15)
+	require.NoError(t, err)
+
 	// Then
-	c.Assert(delay, Equals, time.Duration(0))
-	c.Assert(err, IsNil)
-	c.Assert(tbs.debugState(), Equals, "{1s: 5}, {10s: 35}")
+	assert.Equal(t, time.Duration(0), delay)
+	assert.Equal(t, "{1s: 5}, {10s: 35}", tbs.debugState())
 }
 
 // As time goes by all set buckets are refilled with appropriate rates.
-func (s *BucketSetSuite) TestConsumeRefill(c *C) {
+func TestConsumeRefill(t *testing.T) {
 	// Given
 	rates := NewRateSet()
-	rates.Add(10*time.Second, 10, 20)
-	rates.Add(100*time.Second, 20, 50)
-	tbs := NewTokenBucketSet(rates, s.clock)
-	tbs.Consume(15)
-	c.Assert(tbs.debugState(), Equals, "{10s: 5}, {1m40s: 35}")
+	require.NoError(t, rates.Add(10*time.Second, 10, 20))
+	require.NoError(t, rates.Add(100*time.Second, 20, 50))
+
+	clock := testutils.GetClock()
+
+	tbs := NewTokenBucketSet(rates, clock)
+
+	_, err := tbs.Consume(15)
+	require.NoError(t, err)
+	assert.Equal(t, "{10s: 5}, {1m40s: 35}", tbs.debugState())
+
 	// When
-	s.clock.Sleep(10 * time.Second)
+	clock.Sleep(10 * time.Second)
+
 	delay, err := tbs.Consume(0) // Consumes nothing but forces an internal state update.
+	require.NoError(t, err)
+
 	// Then
-	c.Assert(delay, Equals, time.Duration(0))
-	c.Assert(err, IsNil)
-	c.Assert(tbs.debugState(), Equals, "{10s: 15}, {1m40s: 37}")
+	assert.Equal(t, time.Duration(0), delay)
+	assert.Equal(t, "{10s: 15}, {1m40s: 37}", tbs.debugState())
 }
 
 // If the first bucket in the set has no enough tokens to allow desired
 // consumption then an appropriate delay is returned.
-func (s *BucketSetSuite) TestConsumeLimitedBy1st(c *C) {
+func TestConsumeLimitedBy1st(t *testing.T) {
 	// Given
 	rates := NewRateSet()
-	rates.Add(10*time.Second, 10, 10)
-	rates.Add(100*time.Second, 20, 20)
-	tbs := NewTokenBucketSet(rates, s.clock)
-	tbs.Consume(5)
-	c.Assert(tbs.debugState(), Equals, "{10s: 5}, {1m40s: 15}")
+	require.NoError(t, rates.Add(10*time.Second, 10, 10))
+	require.NoError(t, rates.Add(100*time.Second, 20, 20))
+
+	clock := testutils.GetClock()
+
+	tbs := NewTokenBucketSet(rates, clock)
+
+	_, err := tbs.Consume(5)
+	require.NoError(t, err)
+	assert.Equal(t, "{10s: 5}, {1m40s: 15}", tbs.debugState())
+
 	// When
 	delay, err := tbs.Consume(10)
+	require.NoError(t, err)
+
 	// Then
-	c.Assert(delay, Equals, 5*time.Second)
-	c.Assert(err, IsNil)
-	c.Assert(tbs.debugState(), Equals, "{10s: 5}, {1m40s: 15}")
+	assert.Equal(t, 5*time.Second, delay)
+	assert.Equal(t, "{10s: 5}, {1m40s: 15}", tbs.debugState())
 }
 
 // If the second bucket in the set has no enough tokens to allow desired
 // consumption then an appropriate delay is returned.
-func (s *BucketSetSuite) TestConsumeLimitedBy2st(c *C) {
+func TestConsumeLimitedBy2st(t *testing.T) {
 	// Given
 	rates := NewRateSet()
-	rates.Add(10*time.Second, 10, 10)
-	rates.Add(100*time.Second, 20, 20)
-	tbs := NewTokenBucketSet(rates, s.clock)
-	tbs.Consume(10)
-	s.clock.Sleep(10 * time.Second)
-	tbs.Consume(10)
-	s.clock.Sleep(5 * time.Second)
-	tbs.Consume(0)
-	c.Assert(tbs.debugState(), Equals, "{10s: 5}, {1m40s: 3}")
+	require.NoError(t, rates.Add(10*time.Second, 10, 10))
+	require.NoError(t, rates.Add(100*time.Second, 20, 20))
+
+	clock := testutils.GetClock()
+
+	tbs := NewTokenBucketSet(rates, clock)
+
+	_, err := tbs.Consume(10)
+	require.NoError(t, err)
+
+	clock.Sleep(10 * time.Second)
+
+	_, err = tbs.Consume(10)
+	require.NoError(t, err)
+
+	clock.Sleep(5 * time.Second)
+
+	_, err = tbs.Consume(0)
+	require.NoError(t, err)
+	assert.Equal(t, "{10s: 5}, {1m40s: 3}", tbs.debugState())
+
 	// When
 	delay, err := tbs.Consume(10)
+	require.NoError(t, err)
+
 	// Then
-	c.Assert(delay, Equals, 7*(5*time.Second))
-	c.Assert(err, IsNil)
-	c.Assert(tbs.debugState(), Equals, "{10s: 5}, {1m40s: 3}")
+	assert.Equal(t, 7*(5*time.Second), delay)
+	assert.Equal(t, "{10s: 5}, {1m40s: 3}", tbs.debugState())
 }
 
 // An attempt to consume more tokens then the smallest bucket capacity results
 // in error.
-func (s *BucketSetSuite) TestConsumeMoreThenBurst(c *C) {
+func TestConsumeMoreThenBurst(t *testing.T) {
 	// Given
 	rates := NewRateSet()
-	rates.Add(1*time.Second, 10, 20)
-	rates.Add(10*time.Second, 50, 100)
-	tbs := NewTokenBucketSet(rates, s.clock)
-	tbs.Consume(5)
-	c.Assert(tbs.debugState(), Equals, "{1s: 15}, {10s: 95}")
+	require.NoError(t, rates.Add(1*time.Second, 10, 20))
+	require.NoError(t, rates.Add(10*time.Second, 50, 100))
+
+	clock := testutils.GetClock()
+
+	tbs := NewTokenBucketSet(rates, clock)
+
+	_, err := tbs.Consume(5)
+	require.NoError(t, err)
+	assert.Equal(t, "{1s: 15}, {10s: 95}", tbs.debugState())
+
 	// When
-	_, err := tbs.Consume(21)
-	//Then
-	c.Assert(tbs.debugState(), Equals, "{1s: 15}, {10s: 95}")
-	c.Assert(err, NotNil)
+	_, err = tbs.Consume(21)
+	require.Error(t, err)
+
+	// Then
+	assert.Equal(t, "{1s: 15}, {10s: 95}", tbs.debugState())
 }
 
 // Update operation can add buckets.
-func (s *BucketSetSuite) TestUpdateMore(c *C) {
+func TestUpdateMore(t *testing.T) {
 	// Given
 	rates := NewRateSet()
-	rates.Add(1*time.Second, 10, 20)
-	rates.Add(10*time.Second, 20, 50)
-	rates.Add(20*time.Second, 45, 90)
-	tbs := NewTokenBucketSet(rates, s.clock)
-	tbs.Consume(5)
-	c.Assert(tbs.debugState(), Equals, "{1s: 15}, {10s: 45}, {20s: 85}")
+	require.NoError(t, rates.Add(1*time.Second, 10, 20))
+	require.NoError(t, rates.Add(10*time.Second, 20, 50))
+	require.NoError(t, rates.Add(20*time.Second, 45, 90))
+
+	clock := testutils.GetClock()
+
+	tbs := NewTokenBucketSet(rates, clock)
+
+	_, err := tbs.Consume(5)
+	require.NoError(t, err)
+	assert.Equal(t, "{1s: 15}, {10s: 45}, {20s: 85}", tbs.debugState())
+
 	rates = NewRateSet()
-	rates.Add(10*time.Second, 30, 40)
-	rates.Add(11*time.Second, 30, 40)
-	rates.Add(12*time.Second, 30, 40)
-	rates.Add(13*time.Second, 30, 40)
+	require.NoError(t, rates.Add(10*time.Second, 30, 40))
+	require.NoError(t, rates.Add(11*time.Second, 30, 40))
+	require.NoError(t, rates.Add(12*time.Second, 30, 40))
+	require.NoError(t, rates.Add(13*time.Second, 30, 40))
+
 	// When
 	tbs.Update(rates)
+
 	// Then
-	c.Assert(tbs.debugState(), Equals, "{10s: 40}, {11s: 40}, {12s: 40}, {13s: 40}")
-	c.Assert(tbs.maxPeriod, Equals, 13*time.Second)
+	assert.Equal(t, "{10s: 40}, {11s: 40}, {12s: 40}, {13s: 40}", tbs.debugState())
+	assert.Equal(t, 13*time.Second, tbs.maxPeriod)
 }
 
 // Update operation can remove buckets.
-func (s *BucketSetSuite) TestUpdateLess(c *C) {
+func TestUpdateLess(t *testing.T) {
 	// Given
 	rates := NewRateSet()
-	rates.Add(1*time.Second, 10, 20)
-	rates.Add(10*time.Second, 20, 50)
-	rates.Add(20*time.Second, 45, 90)
-	rates.Add(30*time.Second, 50, 100)
-	tbs := NewTokenBucketSet(rates, s.clock)
-	tbs.Consume(5)
-	c.Assert(tbs.debugState(), Equals, "{1s: 15}, {10s: 45}, {20s: 85}, {30s: 95}")
+	require.NoError(t, rates.Add(1*time.Second, 10, 20))
+	require.NoError(t, rates.Add(10*time.Second, 20, 50))
+	require.NoError(t, rates.Add(20*time.Second, 45, 90))
+	require.NoError(t, rates.Add(30*time.Second, 50, 100))
+
+	clock := testutils.GetClock()
+
+	tbs := NewTokenBucketSet(rates, clock)
+
+	_, err := tbs.Consume(5)
+	require.NoError(t, err)
+	assert.Equal(t, "{1s: 15}, {10s: 45}, {20s: 85}, {30s: 95}", tbs.debugState())
+
 	rates = NewRateSet()
-	rates.Add(10*time.Second, 25, 20)
-	rates.Add(20*time.Second, 30, 21)
+	require.NoError(t, rates.Add(10*time.Second, 25, 20))
+	require.NoError(t, rates.Add(20*time.Second, 30, 21))
+
 	// When
 	tbs.Update(rates)
+
 	// Then
-	c.Assert(tbs.debugState(), Equals, "{10s: 20}, {20s: 21}")
-	c.Assert(tbs.maxPeriod, Equals, 20*time.Second)
+	assert.Equal(t, "{10s: 20}, {20s: 21}", tbs.debugState())
+	assert.Equal(t, 20*time.Second, tbs.maxPeriod)
 }
 
 // Update operation can remove buckets.
-func (s *BucketSetSuite) TestUpdateAllDifferent(c *C) {
+func TestUpdateAllDifferent(t *testing.T) {
 	// Given
 	rates := NewRateSet()
-	rates.Add(10*time.Second, 20, 50)
-	rates.Add(30*time.Second, 50, 100)
-	tbs := NewTokenBucketSet(rates, s.clock)
-	tbs.Consume(5)
-	c.Assert(tbs.debugState(), Equals, "{10s: 45}, {30s: 95}")
+	require.NoError(t, rates.Add(10*time.Second, 20, 50))
+	require.NoError(t, rates.Add(30*time.Second, 50, 100))
+
+	clock := testutils.GetClock()
+
+	tbs := NewTokenBucketSet(rates, clock)
+
+	_, err := tbs.Consume(5)
+	require.NoError(t, err)
+	assert.Equal(t, "{10s: 45}, {30s: 95}", tbs.debugState())
+
 	rates = NewRateSet()
-	rates.Add(1*time.Second, 10, 40)
-	rates.Add(60*time.Second, 100, 150)
+	require.NoError(t, rates.Add(1*time.Second, 10, 40))
+	require.NoError(t, rates.Add(60*time.Second, 100, 150))
+
 	// When
 	tbs.Update(rates)
+
 	// Then
-	c.Assert(tbs.debugState(), Equals, "{1s: 40}, {1m0s: 150}")
-	c.Assert(tbs.maxPeriod, Equals, 60*time.Second)
+	assert.Equal(t, "{1s: 40}, {1m0s: 150}", tbs.debugState())
+	assert.Equal(t, 60*time.Second, tbs.maxPeriod)
 }

--- a/ratelimit/tokenlimiter.go
+++ b/ratelimit/tokenlimiter.go
@@ -32,15 +32,15 @@ func NewRateSet() *RateSet {
 // set then the new rate overrides the old one.
 func (rs *RateSet) Add(period time.Duration, average int64, burst int64) error {
 	if period <= 0 {
-		return fmt.Errorf("Invalid period: %v", period)
+		return fmt.Errorf("invalid period: %v", period)
 	}
 	if average <= 0 {
-		return fmt.Errorf("Invalid average: %v", average)
+		return fmt.Errorf("invalid average: %v", average)
 	}
 	if burst <= 0 {
-		return fmt.Errorf("Invalid burst: %v", burst)
+		return fmt.Errorf("invalid burst: %v", burst)
 	}
-	rs.m[period] = &rate{period, average, burst}
+	rs.m[period] = &rate{period: period, average: average, burst: burst}
 	return nil
 }
 
@@ -79,10 +79,10 @@ type TokenLimiter struct {
 // New constructs a `TokenLimiter` middleware instance.
 func New(next http.Handler, extract utils.SourceExtractor, defaultRates *RateSet, opts ...TokenLimiterOption) (*TokenLimiter, error) {
 	if defaultRates == nil || len(defaultRates.m) == 0 {
-		return nil, fmt.Errorf("Provide default rates")
+		return nil, fmt.Errorf("provide default rates")
 	}
 	if extract == nil {
-		return nil, fmt.Errorf("Provide extract function")
+		return nil, fmt.Errorf("provide extract function")
 	}
 	tl := &TokenLimiter{
 		next:         next,

--- a/ratelimit/tokenlimiter_test.go
+++ b/ratelimit/tokenlimiter_test.go
@@ -4,320 +4,344 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"testing"
 	"time"
 
-	"github.com/mailgun/timetools"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/vulcand/oxy/testutils"
 	"github.com/vulcand/oxy/utils"
-
-	. "gopkg.in/check.v1"
 )
 
-type LimiterSuite struct {
-	clock *timetools.FreezedTime
-}
-
-var _ = Suite(&LimiterSuite{})
-
-func (s *LimiterSuite) SetUpSuite(c *C) {
-	s.clock = &timetools.FreezedTime{
-		CurrentTime: time.Date(2012, 3, 4, 5, 6, 7, 0, time.UTC),
-	}
-}
-
-func (s *LimiterSuite) TestRateSetAdd(c *C) {
+func TestRateSetAdd(t *testing.T) {
 	rs := NewRateSet()
 
 	// Invalid period
 	err := rs.Add(0, 1, 1)
-	c.Assert(err, NotNil)
+	require.Error(t, err)
 
 	// Invalid Average
 	err = rs.Add(time.Second, 0, 1)
-	c.Assert(err, NotNil)
+	require.Error(t, err)
 
 	// Invalid Burst
 	err = rs.Add(time.Second, 1, 0)
-	c.Assert(err, NotNil)
+	require.Error(t, err)
 
 	err = rs.Add(time.Second, 1, 1)
-	c.Assert(err, IsNil)
-	c.Assert("map[1s:rate(1/1s, burst=1)]", Equals, fmt.Sprint(rs))
+	require.NoError(t, err)
+	assert.Equal(t, fmt.Sprint(rs), "map[1s:rate(1/1s, burst=1)]")
 }
 
 // We've hit the limit and were able to proceed on the next time run
-func (s *LimiterSuite) TestHitLimit(c *C) {
+func TestHitLimit(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		w.Write([]byte("hello"))
 	})
 
 	rates := NewRateSet()
-	rates.Add(time.Second, 1, 1)
+	err := rates.Add(time.Second, 1, 1)
+	require.NoError(t, err)
 
-	l, err := New(handler, headerLimit, rates, Clock(s.clock))
-	c.Assert(err, IsNil)
+	clock := testutils.GetClock()
+
+	l, err := New(handler, headerLimit, rates, Clock(clock))
+	require.NoError(t, err)
 
 	srv := httptest.NewServer(l)
 	defer srv.Close()
 
 	re, _, err := testutils.Get(srv.URL, testutils.Header("Source", "a"))
-	c.Assert(err, IsNil)
-	c.Assert(re.StatusCode, Equals, http.StatusOK)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, re.StatusCode)
 
 	// Next request from the same source hits rate limit
 	re, _, err = testutils.Get(srv.URL, testutils.Header("Source", "a"))
-	c.Assert(err, IsNil)
-	c.Assert(re.StatusCode, Equals, 429)
+	require.NoError(t, err)
+	assert.Equal(t, 429, re.StatusCode)
 
 	// Second later, the request from this ip will succeed
-	s.clock.Sleep(time.Second)
+	clock.Sleep(time.Second)
 	re, _, err = testutils.Get(srv.URL, testutils.Header("Source", "a"))
-	c.Assert(err, IsNil)
-	c.Assert(re.StatusCode, Equals, http.StatusOK)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, re.StatusCode)
 }
 
 // We've failed to extract client ip
-func (s *LimiterSuite) TestFailure(c *C) {
+func TestFailure(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		w.Write([]byte("hello"))
 	})
 
 	rates := NewRateSet()
-	rates.Add(time.Second, 1, 1)
+	err := rates.Add(time.Second, 1, 1)
+	require.NoError(t, err)
 
-	l, err := New(handler, faultyExtract, rates, Clock(s.clock))
-	c.Assert(err, IsNil)
+	clock := testutils.GetClock()
+
+	l, err := New(handler, faultyExtract, rates, Clock(clock))
+	require.NoError(t, err)
 
 	srv := httptest.NewServer(l)
 	defer srv.Close()
 
 	re, _, err := testutils.Get(srv.URL, testutils.Header("Source", "a"))
-	c.Assert(err, IsNil)
-	c.Assert(re.StatusCode, Equals, http.StatusInternalServerError)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusInternalServerError, re.StatusCode)
 }
 
 // Make sure rates from different ips are controlled separately
-func (s *LimiterSuite) TestIsolation(c *C) {
+func TestIsolation(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		w.Write([]byte("hello"))
 	})
 
 	rates := NewRateSet()
-	rates.Add(time.Second, 1, 1)
+	err := rates.Add(time.Second, 1, 1)
+	require.NoError(t, err)
 
-	l, err := New(handler, headerLimit, rates, Clock(s.clock))
-	c.Assert(err, IsNil)
+	clock := testutils.GetClock()
+
+	l, err := New(handler, headerLimit, rates, Clock(clock))
+	require.NoError(t, err)
 
 	srv := httptest.NewServer(l)
 	defer srv.Close()
 
 	re, _, err := testutils.Get(srv.URL, testutils.Header("Source", "a"))
-	c.Assert(err, IsNil)
-	c.Assert(re.StatusCode, Equals, http.StatusOK)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, re.StatusCode)
 
 	// Next request from the same source hits rate limit
 	re, _, err = testutils.Get(srv.URL, testutils.Header("Source", "a"))
-	c.Assert(err, IsNil)
-	c.Assert(re.StatusCode, Equals, 429)
+	require.NoError(t, err)
+	assert.Equal(t, 429, re.StatusCode)
 
 	// The request from other source can proceed
 	re, _, err = testutils.Get(srv.URL, testutils.Header("Source", "b"))
-	c.Assert(err, IsNil)
-	c.Assert(re.StatusCode, Equals, http.StatusOK)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, re.StatusCode)
 }
 
 // Make sure that expiration works (Expiration is triggered after significant amount of time passes)
-func (s *LimiterSuite) TestExpiration(c *C) {
+func TestExpiration(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		w.Write([]byte("hello"))
 	})
 
 	rates := NewRateSet()
-	rates.Add(time.Second, 1, 1)
+	err := rates.Add(time.Second, 1, 1)
+	require.NoError(t, err)
 
-	l, err := New(handler, headerLimit, rates, Clock(s.clock))
-	c.Assert(err, IsNil)
+	clock := testutils.GetClock()
+
+	l, err := New(handler, headerLimit, rates, Clock(clock))
+	require.NoError(t, err)
 
 	srv := httptest.NewServer(l)
 	defer srv.Close()
 
 	re, _, err := testutils.Get(srv.URL, testutils.Header("Source", "a"))
-	c.Assert(err, IsNil)
-	c.Assert(re.StatusCode, Equals, http.StatusOK)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, re.StatusCode)
 
 	// Next request from the same source hits rate limit
 	re, _, err = testutils.Get(srv.URL, testutils.Header("Source", "a"))
-	c.Assert(err, IsNil)
-	c.Assert(re.StatusCode, Equals, 429)
+	require.NoError(t, err)
+	assert.Equal(t, 429, re.StatusCode)
 
 	// 24 hours later, the request from this ip will succeed
-	s.clock.Sleep(24 * time.Hour)
+	clock.Sleep(24 * time.Hour)
+
 	re, _, err = testutils.Get(srv.URL, testutils.Header("Source", "a"))
-	c.Assert(err, IsNil)
-	c.Assert(re.StatusCode, Equals, http.StatusOK)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, re.StatusCode)
 }
 
 // If rate limiting configuration is valid, then it is applied.
-func (s *LimiterSuite) TestExtractRates(c *C) {
+func TestExtractRates(t *testing.T) {
 	// Given
 	extractRates := func(*http.Request) (*RateSet, error) {
 		rates := NewRateSet()
-		rates.Add(time.Second, 2, 2)
-		rates.Add(60*time.Second, 10, 10)
+		err := rates.Add(time.Second, 2, 2)
+		if err != nil {
+			return nil, err
+		}
+		err = rates.Add(60*time.Second, 10, 10)
+		if err != nil {
+			return nil, err
+		}
 		return rates, nil
 	}
+
 	rates := NewRateSet()
-	rates.Add(time.Second, 1, 1)
+	err := rates.Add(time.Second, 1, 1)
+	require.NoError(t, err)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		w.Write([]byte("hello"))
 	})
 
-	tl, err := New(handler, headerLimit, rates, Clock(s.clock), ExtractRates(RateExtractorFunc(extractRates)))
-	c.Assert(err, IsNil)
+	clock := testutils.GetClock()
+
+	tl, err := New(handler, headerLimit, rates, Clock(clock), ExtractRates(RateExtractorFunc(extractRates)))
+	require.NoError(t, err)
 
 	srv := httptest.NewServer(tl)
 	defer srv.Close()
 
 	// When/Then: The configured rate is applied, which 2 req/second
 	re, _, err := testutils.Get(srv.URL, testutils.Header("Source", "a"))
-	c.Assert(err, IsNil)
-	c.Assert(re.StatusCode, Equals, http.StatusOK)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, re.StatusCode)
 
 	re, _, err = testutils.Get(srv.URL, testutils.Header("Source", "a"))
-	c.Assert(err, IsNil)
-	c.Assert(re.StatusCode, Equals, http.StatusOK)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, re.StatusCode)
 
 	re, _, err = testutils.Get(srv.URL, testutils.Header("Source", "a"))
-	c.Assert(err, IsNil)
-	c.Assert(re.StatusCode, Equals, 429)
+	require.NoError(t, err)
+	assert.Equal(t, 429, re.StatusCode)
 
-	s.clock.Sleep(time.Second)
+	clock.Sleep(time.Second)
 	re, _, err = testutils.Get(srv.URL, testutils.Header("Source", "a"))
-	c.Assert(err, IsNil)
-	c.Assert(re.StatusCode, Equals, http.StatusOK)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, re.StatusCode)
 }
 
 // If configMapper returns error, then the default rate is applied.
-func (s *LimiterSuite) TestBadRateExtractor(c *C) {
+func TestBadRateExtractor(t *testing.T) {
 	// Given
 	extractor := func(*http.Request) (*RateSet, error) {
 		return nil, fmt.Errorf("boom")
 	}
+
 	rates := NewRateSet()
-	rates.Add(time.Second, 1, 1)
+	err := rates.Add(time.Second, 1, 1)
+	require.NoError(t, err)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		w.Write([]byte("hello"))
 	})
 
-	l, err := New(handler, headerLimit, rates, Clock(s.clock), ExtractRates(RateExtractorFunc(extractor)))
-	c.Assert(err, IsNil)
+	clock := testutils.GetClock()
+
+	l, err := New(handler, headerLimit, rates, Clock(clock), ExtractRates(RateExtractorFunc(extractor)))
+	require.NoError(t, err)
 
 	srv := httptest.NewServer(l)
 	defer srv.Close()
 
 	// When/Then: The default rate is applied, which 1 req/second
 	re, _, err := testutils.Get(srv.URL, testutils.Header("Source", "a"))
-	c.Assert(err, IsNil)
-	c.Assert(re.StatusCode, Equals, http.StatusOK)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, re.StatusCode)
 
 	re, _, err = testutils.Get(srv.URL, testutils.Header("Source", "a"))
-	c.Assert(err, IsNil)
-	c.Assert(re.StatusCode, Equals, 429)
+	require.NoError(t, err)
+	assert.Equal(t, 429, re.StatusCode)
 
-	s.clock.Sleep(time.Second)
+	clock.Sleep(time.Second)
 	re, _, err = testutils.Get(srv.URL, testutils.Header("Source", "a"))
-	c.Assert(err, IsNil)
-	c.Assert(re.StatusCode, Equals, http.StatusOK)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, re.StatusCode)
 }
 
 // If configMapper returns empty rates, then the default rate is applied.
-func (s *LimiterSuite) TestExtractorEmpty(c *C) {
+func TestExtractorEmpty(t *testing.T) {
 	// Given
 	extractor := func(*http.Request) (*RateSet, error) {
 		return NewRateSet(), nil
 	}
+
 	rates := NewRateSet()
-	rates.Add(time.Second, 1, 1)
+	err := rates.Add(time.Second, 1, 1)
+	require.NoError(t, err)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		w.Write([]byte("hello"))
 	})
 
-	l, err := New(handler, headerLimit, rates, Clock(s.clock), ExtractRates(RateExtractorFunc(extractor)))
-	c.Assert(err, IsNil)
+	clock := testutils.GetClock()
+
+	l, err := New(handler, headerLimit, rates, Clock(clock), ExtractRates(RateExtractorFunc(extractor)))
+	require.NoError(t, err)
 
 	srv := httptest.NewServer(l)
 	defer srv.Close()
 
 	// When/Then: The default rate is applied, which 1 req/second
 	re, _, err := testutils.Get(srv.URL, testutils.Header("Source", "a"))
-	c.Assert(err, IsNil)
-	c.Assert(re.StatusCode, Equals, http.StatusOK)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, re.StatusCode)
 
 	re, _, err = testutils.Get(srv.URL, testutils.Header("Source", "a"))
-	c.Assert(err, IsNil)
-	c.Assert(re.StatusCode, Equals, 429)
+	require.NoError(t, err)
+	assert.Equal(t, 429, re.StatusCode)
 
-	s.clock.Sleep(time.Second)
+	clock.Sleep(time.Second)
+
 	re, _, err = testutils.Get(srv.URL, testutils.Header("Source", "a"))
-	c.Assert(err, IsNil)
-	c.Assert(re.StatusCode, Equals, http.StatusOK)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, re.StatusCode)
 }
 
-func (s *LimiterSuite) TestInvalidParams(c *C) {
+func TestInvalidParams(t *testing.T) {
 	// Rates are missing
 	rs := NewRateSet()
-	rs.Add(time.Second, 1, 1)
+	err := rs.Add(time.Second, 1, 1)
+	require.NoError(t, err)
 
 	// Empty
-	_, err := New(nil, nil, rs)
-	c.Assert(err, NotNil)
+	_, err = New(nil, nil, rs)
+	require.Error(t, err)
 
 	// Rates are empty
 	_, err = New(nil, nil, NewRateSet())
-	c.Assert(err, NotNil)
+	require.Error(t, err)
 
 	// Bad capacity
 	_, err = New(nil, headerLimit, rs, Capacity(-1))
-	c.Assert(err, NotNil)
+	require.Error(t, err)
 }
 
 // We've hit the limit and were able to proceed on the next time run
-func (s *LimiterSuite) TestOptions(c *C) {
+func TestOptions(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		w.Write([]byte("hello"))
 	})
 
 	rates := NewRateSet()
-	rates.Add(time.Second, 1, 1)
+	err := rates.Add(time.Second, 1, 1)
+	require.NoError(t, err)
 
 	errHandler := utils.ErrorHandlerFunc(func(w http.ResponseWriter, req *http.Request, err error) {
 		w.WriteHeader(http.StatusTeapot)
 		w.Write([]byte(http.StatusText(http.StatusTeapot)))
 	})
 
-	l, err := New(handler, headerLimit, rates, ErrorHandler(errHandler), Clock(s.clock))
-	c.Assert(err, IsNil)
+	clock := testutils.GetClock()
+
+	l, err := New(handler, headerLimit, rates, ErrorHandler(errHandler), Clock(clock))
+	require.NoError(t, err)
 
 	srv := httptest.NewServer(l)
 	defer srv.Close()
 
 	re, _, err := testutils.Get(srv.URL, testutils.Header("Source", "a"))
-	c.Assert(err, IsNil)
-	c.Assert(re.StatusCode, Equals, http.StatusOK)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, re.StatusCode)
 
 	re, _, err = testutils.Get(srv.URL, testutils.Header("Source", "a"))
-	c.Assert(err, IsNil)
-	c.Assert(re.StatusCode, Equals, http.StatusTeapot)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusTeapot, re.StatusCode)
 }
 
 func headerLimiter(req *http.Request) (string, int64, error) {
 	return req.Header.Get("Source"), 1, nil
 }
 
-func faultyExtractor(req *http.Request) (string, int64, error) {
+func faultyExtractor(_ *http.Request) (string, int64, error) {
 	return "", -1, fmt.Errorf("oops")
 }
 

--- a/roundrobin/rebalancer.go
+++ b/roundrobin/rebalancer.go
@@ -190,7 +190,7 @@ func (rb *Rebalancer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	if !stuck {
-		url, err := rb.next.NextServer()
+		fwdURL, err := rb.next.NextServer()
 		if err != nil {
 			rb.errHandler.ServeHTTP(w, req, err)
 			return
@@ -198,14 +198,14 @@ func (rb *Rebalancer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 		if log.GetLevel() >= log.DebugLevel {
 			// log which backend URL we're sending this request to
-			log.WithFields(log.Fields{"Request": utils.DumpHttpRequest(req), "ForwardURL": url}).Debugf("vulcand/oxy/roundrobin/rebalancer: Forwarding this request to URL")
+			log.WithFields(log.Fields{"Request": utils.DumpHttpRequest(req), "ForwardURL": fwdURL}).Debugf("vulcand/oxy/roundrobin/rebalancer: Forwarding this request to URL")
 		}
 
 		if rb.stickySession != nil {
-			rb.stickySession.StickBackend(url, &w)
+			rb.stickySession.StickBackend(fwdURL, &w)
 		}
 
-		newReq.URL = url
+		newReq.URL = fwdURL
 	}
 
 	// Emit event to a listener if one exists

--- a/roundrobin/stickysessions.go
+++ b/roundrobin/stickysessions.go
@@ -12,7 +12,7 @@ type StickySession struct {
 
 // NewStickySession creates a new StickySession
 func NewStickySession(cookieName string) *StickySession {
-	return &StickySession{cookieName}
+	return &StickySession{cookieName: cookieName}
 }
 
 // GetBackend returns the backend URL stored in the sticky cookie, iff the backend is still in the valid list of servers.

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -8,7 +8,9 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"time"
 
+	"github.com/mailgun/timetools"
 	"github.com/vulcand/oxy/utils"
 )
 
@@ -114,7 +116,12 @@ func MakeRequest(url string, opts ...ReqOption) (*http.Response, []byte, error) 
 	if o.Method == "" {
 		o.Method = http.MethodGet
 	}
-	request, _ := http.NewRequest(o.Method, url, strings.NewReader(o.Body))
+
+	request, err := http.NewRequest(o.Method, url, strings.NewReader(o.Body))
+	if err != nil {
+		return nil, nil, err
+	}
+
 	if o.Headers != nil {
 		utils.CopyHeaders(request.Header, o.Headers)
 	}
@@ -160,4 +167,11 @@ func MakeRequest(url string, opts ...ReqOption) (*http.Response, []byte, error) 
 func Get(url string, opts ...ReqOption) (*http.Response, []byte, error) {
 	opts = append(opts, Method(http.MethodGet))
 	return MakeRequest(url, opts...)
+}
+
+// GetClock gets a FreezedTime
+func GetClock() *timetools.FreezedTime {
+	return &timetools.FreezedTime{
+		CurrentTime: time.Date(2012, 3, 4, 5, 6, 7, 0, time.UTC),
+	}
 }

--- a/utils/auth_test.go
+++ b/utils/auth_test.go
@@ -1,38 +1,36 @@
 package utils
 
 import (
-	. "gopkg.in/check.v1"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-type AuthSuite struct {
-}
-
-var _ = Suite(&AuthSuite{})
-
-//Just to make sure we don't panic, return err and not
-//username and pass and cover the function
-func (s *AuthSuite) TestParseBadHeaders(c *C) {
+// Just to make sure we don't panic, return err and not
+// username and pass and cover the function
+func TestParseBadHeaders(t *testing.T) {
 	headers := []string{
-		//just empty string
+		// just empty string
 		"",
-		//missing auth type
+		// missing auth type
 		"justplainstring",
-		//unknown auth type
+		// unknown auth type
 		"Whut justplainstring",
-		//invalid base64
+		// invalid base64
 		"Basic Shmasic",
-		//random encoded string
+		// random encoded string
 		"Basic YW55IGNhcm5hbCBwbGVhcw==",
 	}
 	for _, h := range headers {
 		_, err := ParseAuthHeader(h)
-		c.Assert(err, NotNil)
+		require.Error(t, err)
 	}
 }
 
-//Just to make sure we don't panic, return err and not
-//username and pass and cover the function
-func (s *AuthSuite) TestParseSuccess(c *C) {
+// Just to make sure we don't panic, return err and not
+// username and pass and cover the function
+func TestParseSuccess(t *testing.T) {
 	headers := []struct {
 		Header   string
 		Expected BasicAuth
@@ -46,7 +44,7 @@ func (s *AuthSuite) TestParseSuccess(c *C) {
 			(&BasicAuth{Username: "Alice", Password: "Here's bob"}).String(),
 			BasicAuth{Username: "Alice", Password: "Here's bob"},
 		},
-		//empty pass
+		// empty pass
 		{
 			"Basic QWxhZGRpbjo=",
 			BasicAuth{Username: "Aladdin", Password: ""},
@@ -54,9 +52,9 @@ func (s *AuthSuite) TestParseSuccess(c *C) {
 	}
 	for _, h := range headers {
 		request, err := ParseAuthHeader(h.Header)
-		c.Assert(err, IsNil)
-		c.Assert(request.Username, Equals, h.Expected.Username)
-		c.Assert(request.Password, Equals, h.Expected.Password)
+		require.NoError(t, err)
+		assert.Equal(t, h.Expected.Username, request.Username)
+		assert.Equal(t, h.Expected.Password, request.Password)
 
 	}
 }

--- a/utils/dumpreq_test.go
+++ b/utils/dumpreq_test.go
@@ -1,18 +1,14 @@
 package utils
 
 import (
-	. "gopkg.in/check.v1"
 	"net/http"
 	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-type DumpHttpReqSuite struct {
-}
-
-var _ = Suite(&DumpHttpReqSuite{})
-
-type readCloserTestImpl struct {
-}
+type readCloserTestImpl struct{}
 
 func (r *readCloserTestImpl) Read(p []byte) (n int, err error) {
 	return 0, nil
@@ -22,15 +18,15 @@ func (r *readCloserTestImpl) Close() error {
 	return nil
 }
 
-//Just to make sure we don't panic, return err and not
-//username and pass and cover the function
-func (s *DumpHttpReqSuite) TestHttpReqToString(c *C) {
+// Just to make sure we don't panic, return err and not
+// username and pass and cover the function
+func TestHttpReqToString(t *testing.T) {
 	req := &http.Request{
 		URL:    &url.URL{Host: "localhost:2374", Path: "/unittest"},
-		Method: "DELETE",
+		Method: http.MethodDelete,
 		Cancel: make(chan struct{}),
 		Body:   &readCloserTestImpl{},
 	}
 
-	c.Assert(len(DumpHttpRequest(req)) > 0, Equals, true)
+	assert.True(t, len(DumpHttpRequest(req)) > 0)
 }

--- a/utils/handler_test.go
+++ b/utils/handler_test.go
@@ -5,15 +5,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"testing"
 
-	. "gopkg.in/check.v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-type UtilsSuite struct{}
-
-var _ = Suite(&UtilsSuite{})
-
-func (s *UtilsSuite) TestDefaultHandlerErrors(c *C) {
+func TestDefaultHandlerErrors(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		h := w.(http.Hijacker)
 		conn, _, _ := h.Hijack()
@@ -21,8 +19,8 @@ func (s *UtilsSuite) TestDefaultHandlerErrors(c *C) {
 	}))
 	defer srv.Close()
 
-	request, err := http.NewRequest("GET", srv.URL, strings.NewReader(""))
-	c.Assert(err, IsNil)
+	request, err := http.NewRequest(http.MethodGet, srv.URL, strings.NewReader(""))
+	require.NoError(t, err)
 
 	_, err = http.DefaultTransport.RoundTrip(request)
 
@@ -30,5 +28,5 @@ func (s *UtilsSuite) TestDefaultHandlerErrors(c *C) {
 
 	DefaultHandler.ServeHTTP(w, nil, err)
 
-	c.Assert(w.Code, Equals, http.StatusBadGateway)
+	assert.Equal(t, http.StatusBadGateway, w.Code)
 }

--- a/utils/netutils.go
+++ b/utils/netutils.go
@@ -153,7 +153,7 @@ func (*nopWriteCloser) Close() error { return nil }
 // NopWriteCloser returns a WriteCloser with a no-op Close method wrapping
 // the provided Writer w.
 func NopWriteCloser(w io.Writer) io.WriteCloser {
-	return &nopWriteCloser{w}
+	return &nopWriteCloser{Writer: w}
 }
 
 // CopyURL provides update safe copy by avoiding shallow copying User field

--- a/utils/netutils_test.go
+++ b/utils/netutils_test.go
@@ -5,18 +5,12 @@ import (
 	"net/url"
 	"testing"
 
-	. "gopkg.in/check.v1"
+	"github.com/stretchr/testify/assert"
 )
-
-func TestUtils(t *testing.T) { TestingT(t) }
-
-type NetUtilsSuite struct{}
-
-var _ = Suite(&NetUtilsSuite{})
 
 // Make sure copy does it right, so the copied url
 // is safe to alter without modifying the other
-func (s *NetUtilsSuite) TestCopyUrl(c *C) {
+func TestCopyUrl(t *testing.T) {
 	urlA := &url.URL{
 		Scheme:   "http",
 		Host:     "localhost:5000",
@@ -26,45 +20,51 @@ func (s *NetUtilsSuite) TestCopyUrl(c *C) {
 		Fragment: "#hello",
 		User:     &url.Userinfo{},
 	}
+
 	urlB := CopyURL(urlA)
-	c.Assert(urlB, DeepEquals, urlA)
+	assert.Equal(t, urlA, urlB)
+
 	urlB.Scheme = "https"
-	c.Assert(urlB, Not(DeepEquals), urlA)
+	assert.NotEqual(t, urlA, urlB)
 }
 
 // Make sure copy headers is not shallow and copies all headers
-func (s *NetUtilsSuite) TestCopyHeaders(c *C) {
+func TestCopyHeaders(t *testing.T) {
 	source, destination := make(http.Header), make(http.Header)
 	source.Add("a", "b")
 	source.Add("c", "d")
 
 	CopyHeaders(destination, source)
 
-	c.Assert(destination.Get("a"), Equals, "b")
-	c.Assert(destination.Get("c"), Equals, "d")
+	assert.Equal(t, "b", destination.Get("a"))
+	assert.Equal(t, "d", destination.Get("c"))
 
 	// make sure that altering source does not affect the destination
 	source.Del("a")
-	c.Assert(source.Get("a"), Equals, "")
-	c.Assert(destination.Get("a"), Equals, "b")
+
+	assert.Equal(t, "", source.Get("a"))
+	assert.Equal(t, "b", destination.Get("a"))
 }
 
-func (s *NetUtilsSuite) TestHasHeaders(c *C) {
+func TestHasHeaders(t *testing.T) {
 	source := make(http.Header)
 	source.Add("a", "b")
 	source.Add("c", "d")
-	c.Assert(HasHeaders([]string{"a", "f"}, source), Equals, true)
-	c.Assert(HasHeaders([]string{"i", "j"}, source), Equals, false)
+
+	assert.True(t, HasHeaders([]string{"a", "f"}, source))
+	assert.False(t, HasHeaders([]string{"i", "j"}, source))
 }
 
-func (s *NetUtilsSuite) TestRemoveHeaders(c *C) {
+func TestRemoveHeaders(t *testing.T) {
 	source := make(http.Header)
 	source.Add("a", "b")
 	source.Add("a", "m")
 	source.Add("c", "d")
+
 	RemoveHeaders(source, "a")
-	c.Assert(source.Get("a"), Equals, "")
-	c.Assert(source.Get("c"), Equals, "d")
+
+	assert.Equal(t, "", source.Get("a"))
+	assert.Equal(t, "d", source.Get("c"))
 }
 
 func BenchmarkCopyHeaders(b *testing.B) {


### PR DESCRIPTION
Migrate from go-check to Testify, because:
- go-check is not really maintained
- go-check have several bugs
- Testify allow to return parallel tests
