### PR TITLE
Adding forwarding for websocket for Ping and Pong messages

### DIFF
--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -395,6 +395,15 @@ func (f *httpForwarder) serveWebSocket(w http.ResponseWriter, req *http.Request,
 	errClient := make(chan error, 1)
 	errBackend := make(chan error, 1)
 	replicateWebsocketConn := func(dst, src *websocket.Conn, errc chan error) {
+
+		src.SetPingHandler(func(data string) error {
+			return dst.WriteMessage(websocket.PingMessage, []byte(data))
+		})
+
+		src.SetPongHandler(func(data string) error {
+			return dst.WriteMessage(websocket.PongMessage, []byte(data))
+		})
+
 		for {
 			msgType, msg, err := src.ReadMessage()
 

--- a/forward/fwd_websocket_test.go
+++ b/forward/fwd_websocket_test.go
@@ -109,7 +109,6 @@ func TestWebSocketPingPong(t *testing.T) {
 	f, err := New()
 	require.NoError(t, err)
 
-
 	var upgrader = gorillawebsocket.Upgrader{
 		HandshakeTimeout: 10 * time.Second,
 		CheckOrigin: func(*http.Request) bool {
@@ -123,13 +122,12 @@ func TestWebSocketPingPong(t *testing.T) {
 		require.NoError(t, err)
 
 		ws.SetPingHandler(func(appData string) error {
-			ws.WriteMessage(gorillawebsocket.PongMessage, []byte(appData + "Pong"))
+			ws.WriteMessage(gorillawebsocket.PongMessage, []byte(appData+"Pong"))
 			return nil
 		})
 
 		ws.ReadMessage()
 	})
-
 
 	srv := testutils.NewHandler(func(w http.ResponseWriter, req *http.Request) {
 		mux.ServeHTTP(w, req)
@@ -152,10 +150,10 @@ func TestWebSocketPingPong(t *testing.T) {
 	require.NoError(t, err, "Error during Dial with response: %+v", resp)
 	defer conn.Close()
 
-	goodErr := fmt.Errorf("Signal: %s", "Good data")
-	badErr := fmt.Errorf("Signal: %s", "Bad data")
+	goodErr := fmt.Errorf("signal: %s", "Good data")
+	badErr := fmt.Errorf("signal: %s", "Bad data")
 	conn.SetPongHandler(func(data string) error {
-		if data == "PingPong"{
+		if data == "PingPong" {
 			return goodErr
 		}
 		return badErr
@@ -164,7 +162,7 @@ func TestWebSocketPingPong(t *testing.T) {
 	conn.WriteControl(gorillawebsocket.PingMessage, []byte("Ping"), time.Now().Add(time.Second))
 	_, _, err = conn.ReadMessage()
 
-	if err != goodErr{
+	if err != goodErr {
 		require.NoError(t, err)
 	}
 }

--- a/forward/fwd_websocket_test.go
+++ b/forward/fwd_websocket_test.go
@@ -105,6 +105,70 @@ func TestWebsocketConnectionClosedHook(t *testing.T) {
 	}
 }
 
+func TestWebSocketPingPong(t *testing.T) {
+	f, err := New()
+	require.NoError(t, err)
+
+
+	var upgrader = gorillawebsocket.Upgrader{
+		HandshakeTimeout: 10 * time.Second,
+		CheckOrigin: func(*http.Request) bool {
+			return true
+		},
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ws", func(writer http.ResponseWriter, request *http.Request) {
+		ws, err := upgrader.Upgrade(writer, request, nil)
+		require.NoError(t, err)
+
+		ws.SetPingHandler(func(appData string) error {
+			ws.WriteMessage(gorillawebsocket.PongMessage, []byte(appData + "Pong"))
+			return nil
+		})
+
+		ws.ReadMessage()
+	})
+
+
+	srv := testutils.NewHandler(func(w http.ResponseWriter, req *http.Request) {
+		mux.ServeHTTP(w, req)
+	})
+	defer srv.Close()
+
+	proxy := testutils.NewHandler(func(w http.ResponseWriter, req *http.Request) {
+		req.URL = testutils.ParseURI(srv.URL)
+		f.ServeHTTP(w, req)
+	})
+	defer proxy.Close()
+
+	serverAddr := proxy.Listener.Addr().String()
+
+	headers := http.Header{}
+	webSocketURL := "ws://" + serverAddr + "/ws"
+	headers.Add("Origin", webSocketURL)
+
+	conn, resp, err := gorillawebsocket.DefaultDialer.Dial(webSocketURL, headers)
+	require.NoError(t, err, "Error during Dial with response: %+v", resp)
+	defer conn.Close()
+
+	goodErr := fmt.Errorf("Signal: %s", "Good data")
+	badErr := fmt.Errorf("Signal: %s", "Bad data")
+	conn.SetPongHandler(func(data string) error {
+		if data == "PingPong"{
+			return goodErr
+		}
+		return badErr
+	})
+
+	conn.WriteControl(gorillawebsocket.PingMessage, []byte("Ping"), time.Now().Add(time.Second))
+	_, _, err = conn.ReadMessage()
+
+	if err != goodErr{
+		require.NoError(t, err)
+	}
+}
+
 func TestWebSocketEcho(t *testing.T) {
 	f, err := New()
 	require.NoError(t, err)


### PR DESCRIPTION
#150 

Would allow oxy to forward ping (code 9) and pong (code 10) messages. Not allowing for this creates an obvious issue and forces client and server to re implement ping/pong behavior in their overlaying protocol.   

Since people might depend on the proxy not being transparent in this regard, adding the option to turn on gorilla default Ping/Pong handler could be an alternative