### PR TITLE
Fix an issue on the XForwardedHeader

### DIFF
--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -309,17 +309,17 @@ func (f *httpForwarder) modifyRequest(outReq *http.Request, target *url.URL) {
 	outReq.URL.RawQuery = u.RawQuery
 	outReq.RequestURI = "" // Outgoing request should not have RequestURI
 
-	// Do not pass client Host header unless optsetter PassHostHeader is set.
-	if !f.passHost {
-		outReq.Host = target.Host
-	}
-
 	outReq.Proto = "HTTP/1.1"
 	outReq.ProtoMajor = 1
 	outReq.ProtoMinor = 1
 
 	if f.rewriter != nil {
 		f.rewriter.Rewrite(outReq)
+	}
+
+	// Do not pass client Host header unless optsetter PassHostHeader is set.
+	if !f.passHost {
+		outReq.Host = target.Host
 	}
 }
 

--- a/forward/fwd_test.go
+++ b/forward/fwd_test.go
@@ -5,10 +5,9 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
-
-	"net/url"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
### What does this PR do?

Fix an issue with the `XForwardedHost`. 
If the PassHost was set `true`, the `XForwarded` took the Target host. 

### Motivation
Have an expected XForwardedHost Header.

### More

- [x] Added/updated tests
