### PR TITLE
Fixed 500 reported for client disconnection

### DIFF
--- a/utils/handler.go
+++ b/utils/handler.go
@@ -12,6 +12,9 @@ import (
 // ClientClosedRequest non-standard HTTP status code for client disconnection
 const ClientClosedRequest = 499
 
+// StatusClientClosedRequest non-standard HTTP status for client disconnection
+const StatusClientClosedRequest = "Client Closed Request"
+
 // ErrorHandler error handler
 type ErrorHandler interface {
 	ServeHTTP(w http.ResponseWriter, req *http.Request, err error)
@@ -25,20 +28,27 @@ type StdHandler struct{}
 
 func (e *StdHandler) ServeHTTP(w http.ResponseWriter, req *http.Request, err error) {
 	statusCode := http.StatusInternalServerError
+	statusText := http.StatusText(statusCode)
+
 	if e, ok := err.(net.Error); ok {
 		if e.Timeout() {
 			statusCode = http.StatusGatewayTimeout
+			statusText = http.StatusText(statusCode)
 		} else {
 			statusCode = http.StatusBadGateway
+			statusText = http.StatusText(statusCode)
 		}
-	} else if err == context.Canceled {
-		statusCode = ClientClosedRequest
 	} else if err == io.EOF {
 		statusCode = http.StatusBadGateway
+		statusText = http.StatusText(statusCode)
+	} else if err == context.Canceled {
+		statusCode = ClientClosedRequest
+		statusText = StatusClientClosedRequest
 	}
+
 	w.WriteHeader(statusCode)
-	w.Write([]byte(http.StatusText(statusCode)))
-	log.Debugf("'%d %s' caused by: %v", statusCode, http.StatusText(statusCode), err)
+	w.Write([]byte(statusText))
+	log.Debugf("'%d %s' caused by: %v", statusCode, statusText, err)
 }
 
 // ErrorHandlerFunc error handler function type

--- a/utils/handler.go
+++ b/utils/handler.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"io"
 	"net"
 	"net/http"
@@ -20,6 +21,11 @@ var DefaultHandler ErrorHandler = &StdHandler{}
 type StdHandler struct{}
 
 func (e *StdHandler) ServeHTTP(w http.ResponseWriter, req *http.Request, err error) {
+	if err == context.Canceled {
+		log.Debugf("'%v' probably client disconnection", err)
+		return
+	}
+
 	statusCode := http.StatusInternalServerError
 	if e, ok := err.(net.Error); ok {
 		if e.Timeout() {


### PR DESCRIPTION
# What does this PR do? 

Fix an issue with random 500s reported in Traefik metrics middleware. Issue: https://github.com/containous/traefik/issues/1926

# Motivation
By default oxy middleware reports 500 for Context cancel error, which does not make much sense as in this case the 500 won't be received by the client and further HttpHandlers down the line (like Traefik metrics middleware) can go nuts because of it. I originally had this issue in Traefik so if it doesn't make sense to fix it in oxy I need to find a way how to fix it in Traefik only.

# More
Fixes: https://github.com/containous/traefik/issues/1926
