### PR TITLE
Handle Te header when http2

### DIFF
--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -259,6 +259,8 @@ func New(setters ...optSetter) (*Forwarder, error) {
 		errorHandler: f.errHandler,
 	}
 
+	f.postConfig()
+
 	return f, nil
 }
 

--- a/forward/post_config.go
+++ b/forward/post_config.go
@@ -1,0 +1,5 @@
+// +build go1.11
+
+package forward
+
+func (f *Forwarder) postConfig() {}

--- a/forward/post_config_18.go
+++ b/forward/post_config_18.go
@@ -1,0 +1,42 @@
+// +build !go1.11
+
+package forward
+
+import (
+	"context"
+	"net/http"
+)
+
+type key string
+
+const (
+	teHeader key = "TeHeader"
+)
+
+type TeTrailerRoundTripper struct {
+	http.RoundTripper
+}
+
+func (t *TeTrailerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	teHeader := req.Context().Value(teHeader)
+	if teHeader != nil {
+		req.Header.Set("Te", teHeader.(string))
+	}
+	return t.RoundTripper.RoundTrip(req)
+}
+
+type TeTrailerRewriter struct {
+	ReqRewriter
+}
+
+func (t *TeTrailerRewriter) Rewrite(req *http.Request) {
+	if req.Header.Get("Te") == "trailers" {
+		*req = *req.WithContext(context.WithValue(req.Context(), teHeader, req.Header.Get("Te")))
+	}
+	t.ReqRewriter.Rewrite(req)
+}
+
+func (f *Forwarder) postConfig() {
+	f.roundTripper = &TeTrailerRoundTripper{RoundTripper: f.roundTripper}
+	f.rewriter = &TeTrailerRewriter{ReqRewriter: f.rewriter}
+}

--- a/forward/rewrite.go
+++ b/forward/rewrite.go
@@ -69,12 +69,6 @@ func (rw *HeaderRewriter) Rewrite(req *http.Request) {
 	if rw.Hostname != "" {
 		req.Header.Set(XForwardedServer, rw.Hostname)
 	}
-
-	if !IsWebsocketRequest(req) {
-		// Remove hop-by-hop headers to the backend.  Especially important is "Connection" because we want a persistent
-		// connection, regardless of what the client sent to us.
-		utils.RemoveHeaders(req.Header, HopHeaders...)
-	}
 }
 
 func forwardedPort(req *http.Request) string {


### PR DESCRIPTION
### What does this PR do?
Don't remove `Te` header when its value is `trailers`.
We don't to remove of hop-by-hopb headers in the HeaderRewriter because it's already done in the go reverseproxy.

### Motivation
Fixes #124 

### More

 This fix will be done directly in the go reverse proxy in 1.11 but we need to handle it for previous versions.

- [x] Added/updated tests


