### PR TITLE
Body should never be nil in buffer

### DIFF
--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -330,7 +330,7 @@ func (b *Buffer) copyRequest(req *http.Request, body io.ReadCloser, bodySize int
 	o.TransferEncoding = []string{}
 	// http.Transport will close the request body on any error, we are controlling the close process ourselves, so we override the closer here
 	if body == nil {
-		o.Body = nil
+		o.Body = ioutil.NopCloser(req.Body)
 	} else {
 		o.Body = ioutil.NopCloser(body.(io.Reader))
 	}

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -169,6 +169,12 @@ func Get(url string, opts ...ReqOption) (*http.Response, []byte, error) {
 	return MakeRequest(url, opts...)
 }
 
+// Post do a POST request
+func Post(url string, opts ...ReqOption) (*http.Response, []byte, error) {
+	opts = append(opts, Method(http.MethodPost))
+	return MakeRequest(url, opts...)
+}
+
 // GetClock gets a FreezedTime
 func GetClock() *timetools.FreezedTime {
 	return &timetools.FreezedTime{


### PR DESCRIPTION
### Description

When buffer is enable and the size on the body is equals to 0 the body is set to nil. Its can generate some nil pointer.

So I propose to set body to `ioutil.NopCloser(req.Body)` instead of `nil`

Related to https://github.com/containous/traefik/issues/4005