### PR TITLE
Pass host header for Websocket.

### DIFF
--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -491,6 +491,9 @@ func (f *httpForwarder) copyWebSocketRequest(req *http.Request) (outReq *http.Re
 	outReq.RequestURI = "" // Outgoing request should not have RequestURI
 
 	outReq.URL.Host = req.URL.Host
+	if !f.passHost {
+		outReq.Host = req.URL.Host
+	}
 
 	outReq.Header = make(http.Header)
 	// gorilla websocket use this header to set the request.Host tested in checkSameOrigin


### PR DESCRIPTION
Pass host header for Websocket as HTTP

Related to https://github.com/containous/traefik/issues/4006