### PR TITLE
Keep userinfo in roundrobin after shallow copy

### DIFF
--- a/roundrobin/rr.go
+++ b/roundrobin/rr.go
@@ -144,6 +144,9 @@ func (r *RoundRobin) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		r.requestRewriteListener(req, &newReq)
 	}
 
+	// avoid discarding the userinfo in the URL
+	newReq.URL.User = req.URL.User
+
 	r.next.ServeHTTP(w, &newReq)
 }
 


### PR DESCRIPTION
This PR changes the current behavior of the `roundrobin` middleware to make it keep the original requests' UserInfo rather than to discard it.

It was currently discarded simply because the URL is rewritten after the shallow copy of the original incoming `*http.Request`.