### PR TITLE
memmetrics: Optimize RollingCounter Inc and Count operations

### DIFF
--- a/memmetrics/counter_test.go
+++ b/memmetrics/counter_test.go
@@ -1,6 +1,7 @@
 package memmetrics
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -29,4 +30,52 @@ func TestCloneExpired(t *testing.T) {
 	out := cnt.Clone()
 
 	assert.EqualValues(t, 2, out.Count())
+}
+
+func BenchmarkCounterIncOnly(b *testing.B) {
+	benchmarkCounter(
+		b,
+		func(clock *timetools.FreezedTime, ctr *RollingCounter) {
+			clock.Sleep(time.Second)
+			ctr.Inc(1)
+		},
+	)
+}
+
+func BenchmarkCounterIncCountContigu(b *testing.B) {
+	benchmarkCounter(
+		b,
+		func(clock *timetools.FreezedTime, ctr *RollingCounter) {
+			clock.Sleep(time.Second)
+			ctr.Inc(1)
+			ctr.Count()
+		},
+	)
+}
+
+func BenchmarkCounterIncCountSparse(b *testing.B) {
+	benchmarkCounter(
+		b,
+		func(clock *timetools.FreezedTime, ctr *RollingCounter) {
+			clock.Sleep(5 * time.Second)
+			ctr.Inc(1)
+			ctr.Count()
+		},
+	)
+}
+
+func benchmarkCounter(b *testing.B, fn func(*timetools.FreezedTime, *RollingCounter)) {
+	clockTest := &timetools.FreezedTime{
+		CurrentTime: time.Date(2012, 3, 4, 5, 6, 7, 0, time.UTC),
+	}
+
+	for _, size := range []int{3, 5, 10, 20, 50, 100} {
+		b.Run(fmt.Sprintf("size-%d", size), func(b *testing.B) {
+			cnt, _ := NewCounter(size, time.Second, CounterClock(clockTest))
+
+			for i := 0; i < b.N; i++ {
+				fn(clockTest, cnt)
+			}
+		})
+	}
 }

--- a/memmetrics/ratio.go
+++ b/memmetrics/ratio.go
@@ -60,7 +60,7 @@ func (r *RatioCounter) Reset() {
 
 // IsReady returns true if the counter is ready
 func (r *RatioCounter) IsReady() bool {
-	return r.a.countedBuckets+r.b.countedBuckets >= len(r.a.values)
+	return r.a.CountedBuckets()+r.b.CountedBuckets() >= len(r.a.values)
 }
 
 // CountA gets count A


### PR DESCRIPTION
The overall performance of the counter has been improved, there is a little performance regression in a corner case (large bucket with contiguous values)

Find attached some benchmark results of this modification:

```
benchmark                                      old ns/op     new ns/op     delta
BenchmarkCounterIncOnly/size-3-4               203           53.4          -73.69%
BenchmarkCounterIncOnly/size-5-4               192           52.3          -72.76%
BenchmarkCounterIncOnly/size-10-4              198           59.0          -70.20%
BenchmarkCounterIncOnly/size-20-4              199           62.4          -68.64%
BenchmarkCounterIncOnly/size-50-4              196           58.5          -70.15%
BenchmarkCounterIncOnly/size-100-4             189           57.5          -69.58%
BenchmarkCounterIncCountContigu/size-3-4       249           111           -55.42%
BenchmarkCounterIncCountContigu/size-5-4       249           125           -49.80%
BenchmarkCounterIncCountContigu/size-10-4      262           180           -31.30%
BenchmarkCounterIncCountContigu/size-20-4      257           285           +10.89%
BenchmarkCounterIncCountContigu/size-50-4      270           610           +125.93%
BenchmarkCounterIncCountContigu/size-100-4     295           1054          +257.29%
BenchmarkCounterIncCountSparse/size-3-4        379           104           -72.56%
BenchmarkCounterIncCountSparse/size-5-4        485           95.9          -80.23%
BenchmarkCounterIncCountSparse/size-10-4       482           102           -78.84%
BenchmarkCounterIncCountSparse/size-20-4       478           168           -64.85%
BenchmarkCounterIncCountSparse/size-50-4       488           181           -62.91%
BenchmarkCounterIncCountSparse/size-100-4      494           298           -39.68%
```

FYI: The struct is now really thread safe. 