### PR TITLE
Options for sticky sessions' affinity cookies

### DIFF
--- a/roundrobin/stickysessions.go
+++ b/roundrobin/stickysessions.go
@@ -8,11 +8,24 @@ import (
 // StickySession is a mixin for load balancers that implements layer 7 (http cookie) session affinity
 type StickySession struct {
 	cookieName string
+	options    CookieOptions
+}
+
+// CookieOptions has all the options one would like to set on the affinity cookie
+type CookieOptions struct {
+	httpOnly bool
+	secure   bool
 }
 
 // NewStickySession creates a new StickySession
 func NewStickySession(cookieName string) *StickySession {
 	return &StickySession{cookieName: cookieName}
+}
+
+// NewStickySessionWithOptions creates a new StickySession whilst allowing for options to
+// shape its affinity cookie such as "httpOnly" or "secure"
+func NewStickySessionWithOptions(cookieName string, options CookieOptions) *StickySession {
+	return &StickySession{cookieName: cookieName, options: options}
 }
 
 // GetBackend returns the backend URL stored in the sticky cookie, iff the backend is still in the valid list of servers.
@@ -39,7 +52,8 @@ func (s *StickySession) GetBackend(req *http.Request, servers []*url.URL) (*url.
 
 // StickBackend creates and sets the cookie
 func (s *StickySession) StickBackend(backend *url.URL, w *http.ResponseWriter) {
-	cookie := &http.Cookie{Name: s.cookieName, Value: backend.String(), Path: "/"}
+	opt := s.options
+	cookie := &http.Cookie{Name: s.cookieName, Value: backend.String(), Path: "/", HttpOnly: opt.httpOnly, Secure: opt.secure}
 	http.SetCookie(*w, cookie)
 }
 


### PR DESCRIPTION
"StickySession" type accepts "HttpOnly" and "Secure" options which are subsequently used to set the corresponding flags on the sticky sessions' cookies.