### PR TITLE
doc: typo fix /serveHTTP/serveWebSocket/s

### DIFF
--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -327,7 +327,7 @@ func (f *httpForwarder) modifyRequest(outReq *http.Request, target *url.URL) {
 	}
 }
 
-// serveHTTP forwards websocket traffic
+// serveWebSocket forwards websocket traffic
 func (f *httpForwarder) serveWebSocket(w http.ResponseWriter, req *http.Request, ctx *handlerContext) {
 	if f.log.GetLevel() >= log.DebugLevel {
 		logEntry := f.log.WithField("Request", utils.DumpHttpRequest(req))


### PR DESCRIPTION
From what I can tell, it looks like this comment intended to say serveWebSocket, not serveHTTP.