### PR TITLE
change loglevel for websocket abnormal close from error to debug

### DIFF
--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -468,7 +468,7 @@ func (f *httpForwarder) serveWebSocket(w http.ResponseWriter, req *http.Request,
 
 	}
 	if e, ok := err.(*websocket.CloseError); !ok || e.Code == websocket.CloseAbnormalClosure {
-		f.log.Errorf(message, err)
+		f.log.Debugf(message, err)
 	}
 }
 


### PR DESCRIPTION
abnormal close happens quite often in modern mobile browsers
this prevents spamming the logs with errors