### PR TITLE
Fix memory leak in roundrobin RemoveServer

### DIFF
--- a/roundrobin/rebalancer.go
+++ b/roundrobin/rebalancer.go
@@ -278,7 +278,15 @@ func (rb *Rebalancer) removeServer(u *url.URL) error {
 	if err := rb.next.RemoveServer(u); err != nil {
 		return err
 	}
-	rb.servers = append(rb.servers[:i], rb.servers[i+1:]...)
+
+	// Removing an item from a list of pointers.
+	// https://github.com/golang/go/wiki/SliceTricks
+	if i < len(rb.servers)-1 {
+		copy(rb.servers[i:], rb.servers[i+1:])
+	}
+	rb.servers[len(rb.servers)-1] = nil
+	rb.servers = rb.servers[:len(rb.servers)-1]
+
 	rb.reset()
 	return nil
 }

--- a/roundrobin/rr.go
+++ b/roundrobin/rr.go
@@ -200,7 +200,15 @@ func (r *RoundRobin) RemoveServer(u *url.URL) error {
 	if e == nil {
 		return fmt.Errorf("server not found")
 	}
-	r.servers = append(r.servers[:index], r.servers[index+1:]...)
+
+	// Removing an item from a list of pointers.
+	// https://github.com/golang/go/wiki/SliceTricks
+	if index < len(r.servers)-1 {
+		copy(r.servers[index:], r.servers[index+1:])
+	}
+	r.servers[len(r.servers)-1] = nil
+	r.servers = r.servers[:len(r.servers)-1]
+
 	r.resetState()
 	return nil
 }


### PR DESCRIPTION
Hi there,

I believe I've found a leak here. See https://github.com/golang/go/wiki/SliceTricks on how to manage slices holding pointers.

```
(pprof) top20
Showing nodes accounting for 552.77MB, 71.51% of 772.94MB total
Dropped 191 nodes (cum <= 3.86MB)
Showing top 20 nodes out of 170
      flat  flat%   sum%        cum   cum%
  102.51MB 13.26% 13.26%   102.51MB 13.26%  github.com/containous/traefik/vendor/github.com/vulcand/oxy/utils.CopyURL
      45MB  5.82% 19.08%       45MB  5.82%  github.com/containous/traefik/vendor/github.com/BurntSushi/toml.(*parser).replaceEscapes
   40.15MB  5.20% 24.28%    40.15MB  5.20%  bufio.NewWriterSize
      33MB  4.27% 28.55%       33MB  4.27%  github.com/containous/traefik/vendor/github.com/vulcand/oxy/forward.New
   29.61MB  3.83% 32.38%    29.61MB  3.83%  bufio.NewReaderSize
...
      20MB  2.59% 59.26%   119.51MB 15.46%  github.com/containous/traefik/vendor/github.com/vulcand/oxy/roundrobin.(*RoundRobin).UpsertServer
```

Haven't tested if this makes a difference in production, but we're seeing our Traefik instances slowly going OOM in under 72 hours in 6GiB containers under a 10-20MB/s workload. Above certain heap thresholds, we see the GC pacer back off to running once every 10s, then to once every 30s, until the instance goes OOM. This is the nail that sticks out the most, so we'll give this a try.

(We use `consul-catalog` with about 550 total backends.)