### PR TITLE
Add Fallback setter on CircuitBreaker

### DIFF
--- a/cbreaker/cbreaker.go
+++ b/cbreaker/cbreaker.go
@@ -124,6 +124,11 @@ func (c *CircuitBreaker) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	c.serve(w, req)
 }
 
+// Fallback sets the fallback handler to be called by circuit breaker handler.
+func (c *CircuitBreaker) Fallback(f http.Handler) {
+	c.fallback = f
+}
+
 // Wrap sets the next handler to be called by circuit breaker handler.
 func (c *CircuitBreaker) Wrap(next http.Handler) {
 	c.next = next


### PR DESCRIPTION
I would like to be able to add a Header to the request sent to the Fallback service with the content of `*CircuitBreaker.String()`.

At the moment it is not possible because we need to pass the fallback func to `*CircuitBreaker.New(...)` to get a *CircuitBreaker and then we have no means to update the fallback func.

See https://github.com/containous/traefik/pull/6922