### PR TITLE
Fix panics on ratelimit period (division by zero)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 
 go:
   - 1.14.x
-  - 1.x
+  - 1.15.x
 
 go_import_path: github.com/vulcand/oxy
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.13.x
+  - 1.14.x
   - 1.x
 
 go_import_path: github.com/vulcand/oxy
@@ -19,5 +19,5 @@ before_install:
   - GO111MODULE=off go get -u github.com/client9/misspell/cmd/misspell
 
 install:
-  - go mod download
+  - go mod tidy
   - git diff --exit-code go.mod go.sum

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vulcand/oxy
 
-go 1.13
+go 1.14
 
 require (
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd

--- a/ratelimit/bucket.go
+++ b/ratelimit/bucket.go
@@ -116,7 +116,7 @@ func (tb *tokenBucket) updateAvailableTokens() {
 	now := tb.clock.UtcNow()
 	timePassed := now.Sub(tb.lastRefresh)
 
-	if timePassed == 0 {
+	if tb.timePerToken == 0 {
 		return
 	}
 

--- a/ratelimit/bucket.go
+++ b/ratelimit/bucket.go
@@ -48,6 +48,7 @@ func newTokenBucket(rate *rate, clock timetools.TimeProvider) *tokenBucket {
 	if period == 0 {
 		period = time.Nanosecond
 	}
+
 	return &tokenBucket{
 		period:          period,
 		timePerToken:    time.Duration(int64(period) / rate.average),

--- a/ratelimit/bucket.go
+++ b/ratelimit/bucket.go
@@ -44,9 +44,13 @@ type tokenBucket struct {
 
 // newTokenBucket crates a `tokenBucket` instance for the specified `Rate`.
 func newTokenBucket(rate *rate, clock timetools.TimeProvider) *tokenBucket {
+	period := rate.period
+	if period == 0 {
+		period = time.Nanosecond
+	}
 	return &tokenBucket{
-		period:          rate.period,
-		timePerToken:    time.Duration(int64(rate.period) / rate.average),
+		period:          period,
+		timePerToken:    time.Duration(int64(period) / rate.average),
 		burst:           rate.burst,
 		clock:           clock,
 		lastRefresh:     clock.UtcNow(),
@@ -111,6 +115,10 @@ func (tb *tokenBucket) timeTillAvailable(tokens int64) time.Duration {
 func (tb *tokenBucket) updateAvailableTokens() {
 	now := tb.clock.UtcNow()
 	timePassed := now.Sub(tb.lastRefresh)
+
+	if timePassed == 0 {
+		return
+	}
 
 	tokens := tb.availableTokens + int64(timePassed/tb.timePerToken)
 	// If we haven't added any tokens that means that not enough time has passed,

--- a/ratelimit/bucket_test.go
+++ b/ratelimit/bucket_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mailgun/timetools"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vulcand/oxy/testutils"
@@ -346,7 +347,7 @@ func TestRollbackAfterError(t *testing.T) {
 }
 
 func TestDivisionByZeroOnPeriod(t *testing.T) {
-	clock := testutils.GetClock()
+	clock := &timetools.RealTime{}
 
 	var emptyPeriod int64
 	tb := newTokenBucket(&rate{period: time.Duration(emptyPeriod), average: 2, burst: 2}, clock)

--- a/ratelimit/bucket_test.go
+++ b/ratelimit/bucket_test.go
@@ -344,3 +344,16 @@ func TestRollbackAfterError(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 100*time.Millisecond, delay)
 }
+
+func TestDivisionByZeroOnPeriod(t *testing.T) {
+	clock := testutils.GetClock()
+
+	var emptyPeriod int64
+	tb := newTokenBucket(&rate{period: time.Duration(emptyPeriod), average: 2, burst: 2}, clock)
+
+	_, err := tb.consume(1)
+	assert.NoError(t, err)
+
+	err = tb.update(&rate{period: time.Nanosecond, average: 1, burst: 1})
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Protect from panic when leaving the rate limit period empty (zero value).