### PR TITLE
Bump to go1.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - 1.14.x
   - 1.15.x
+  - 1.x
 
 go_import_path: github.com/vulcand/oxy
 

--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"net/http/httptest"
 	"net/http/httputil"
 	"net/url"
 	"os"
@@ -153,25 +152,6 @@ func StreamingFlushInterval(flushInterval time.Duration) optSetter {
 	}
 }
 
-// ErrorHandlingRoundTripper a error handling round tripper
-type ErrorHandlingRoundTripper struct {
-	http.RoundTripper
-	errorHandler utils.ErrorHandler
-}
-
-// RoundTrip executes the round trip
-func (rt ErrorHandlingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	res, err := rt.RoundTripper.RoundTrip(req)
-	if err != nil {
-		// We use the recorder from httptest because there isn't another `public` implementation of a recorder.
-		recorder := httptest.NewRecorder()
-		rt.errorHandler.ServeHTTP(recorder, req, err)
-		res = recorder.Result()
-		err = nil
-	}
-	return res, err
-}
-
 // Forwarder wraps two traffic forwarding implementations: HTTP and websockets.
 // It decides based on the specified request which implementation to use
 type Forwarder struct {
@@ -252,11 +232,6 @@ func New(setters ...optSetter) (*Forwarder, error) {
 		if ht, ok := f.httpForwarder.roundTripper.(*http.Transport); ok {
 			f.tlsClientConfig = ht.TLSClientConfig
 		}
-	}
-
-	f.httpForwarder.roundTripper = ErrorHandlingRoundTripper{
-		RoundTripper: f.httpForwarder.roundTripper,
-		errorHandler: f.errHandler,
 	}
 
 	f.postConfig()
@@ -533,6 +508,7 @@ func (f *httpForwarder) serveHTTP(w http.ResponseWriter, inReq *http.Request, ct
 		FlushInterval:  f.flushInterval,
 		ModifyResponse: f.modifyResponse,
 		BufferPool:     f.bufferPool,
+		ErrorHandler:   ctx.errHandler.ServeHTTP,
 	}
 
 	if f.log.GetLevel() >= log.DebugLevel {

--- a/forward/fwd_chunked_go1_15_test.go
+++ b/forward/fwd_chunked_go1_15_test.go
@@ -1,0 +1,37 @@
+// +build !go1.16
+
+package forward
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vulcand/oxy/testutils"
+)
+
+func TestChunkedResponseConversion(t *testing.T) {
+	srv := testutils.NewHandler(func(w http.ResponseWriter, req *http.Request) {
+		h := w.(http.Hijacker)
+		conn, _, _ := h.Hijack()
+		fmt.Fprintf(conn, "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n4\r\ntest\r\n5\r\ntest1\r\n5\r\ntest2\r\n0\r\n\r\n")
+		conn.Close()
+	})
+	defer srv.Close()
+
+	f, err := New()
+	require.NoError(t, err)
+
+	proxy := testutils.NewHandler(func(w http.ResponseWriter, req *http.Request) {
+		req.URL = testutils.ParseURI(srv.URL)
+		f.ServeHTTP(w, req)
+	})
+	defer proxy.Close()
+
+	re, body, err := testutils.Get(proxy.URL)
+	require.NoError(t, err)
+	assert.Equal(t, "testtest1test2", string(body))
+	assert.Equal(t, http.StatusOK, re.StatusCode)
+}

--- a/forward/fwd_chunked_test.go
+++ b/forward/fwd_chunked_test.go
@@ -1,0 +1,43 @@
+// +build go1.16
+
+package forward
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vulcand/oxy/testutils"
+)
+
+func TestChunkedResponseConversion(t *testing.T) {
+	srv := testutils.NewHandler(func(w http.ResponseWriter, req *http.Request) {
+		h := w.(http.Hijacker)
+		conn, _, _ := h.Hijack()
+		fmt.Fprintf(conn, "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n4\r\ntest\r\n5\r\ntest1\r\n5\r\ntest2\r\n0\r\n\r\n")
+		conn.Close()
+	})
+	defer srv.Close()
+
+	f, err := New()
+	require.NoError(t, err)
+
+	proxy := testutils.NewHandler(func(w http.ResponseWriter, req *http.Request) {
+		req.URL = testutils.ParseURI(srv.URL)
+		f.ServeHTTP(w, req)
+	})
+	defer proxy.Close()
+
+	re, body, err := testutils.Get(proxy.URL)
+	require.NoError(t, err)
+	assert.Equal(t, "testtest1test2", string(body))
+	assert.Equal(t, http.StatusOK, re.StatusCode)
+
+	// Also as per RFC2616 (https://tools.ietf.org/html/rfc2616#section-4.4)
+	// "Messages MUST NOT include both a Content-Length header field and a non-identity transfer-coding.
+	// If the message does include a non-identity transfer-coding, the Content-Length MUST be ignored."
+	_, ok := re.Header["Content-Length"]
+	assert.False(t, ok)
+}

--- a/forward/fwd_test.go
+++ b/forward/fwd_test.go
@@ -2,7 +2,6 @@ package forward
 
 import (
 	"context"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -329,31 +328,6 @@ func TestForwardedProto(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, re.StatusCode)
 	assert.Equal(t, "https", proto)
-}
-
-func TestChunkedResponseConversion(t *testing.T) {
-	srv := testutils.NewHandler(func(w http.ResponseWriter, req *http.Request) {
-		h := w.(http.Hijacker)
-		conn, _, _ := h.Hijack()
-		fmt.Fprintf(conn, "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n4\r\ntest\r\n5\r\ntest1\r\n5\r\ntest2\r\n0\r\n\r\n")
-		conn.Close()
-	})
-	defer srv.Close()
-
-	f, err := New()
-	require.NoError(t, err)
-
-	proxy := testutils.NewHandler(func(w http.ResponseWriter, req *http.Request) {
-		req.URL = testutils.ParseURI(srv.URL)
-		f.ServeHTTP(w, req)
-	})
-	defer proxy.Close()
-
-	re, body, err := testutils.Get(proxy.URL)
-	require.NoError(t, err)
-	assert.Equal(t, "testtest1test2", string(body))
-	assert.Equal(t, http.StatusOK, re.StatusCode)
-	assert.Equal(t, fmt.Sprintf("%d", len("testtest1test2")), re.Header.Get("Content-Length"))
 }
 
 func TestContextWithValueInErrHandler(t *testing.T) {


### PR DESCRIPTION
This PR bumps to go1.16.

It fixes the test `TestChunkedResponseConversion` of `fwd.go`.

The assertion to check the Content-Length header has been removed because it's not present in response with go1.16.
By enforcing flushes in net/http/httputil/reverseproxy.go when proxying streamed responses with unknown body lengths, in go1.16, the call of flush() method of the net/http/server.go#chunkWriter happens before any call of its Write() method, which leads eventually to the removal of the Content-Length header.
	
Also as per RFC2616 (https://tools.ietf.org/html/rfc2616#section-4.4):

> Messages MUST NOT include both a Content-Length header field and a non-identity transfer-coding. If the message does include a non-identity transfer-coding, the Content-Length MUST be ignored.

The test is now ensuring that `Content-Length` header is not present in the response only for go1.16+.

