### PR TITLE
Add a mechanism to control the sticky cookie value

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/mailgun/multibuf v0.0.0-20150714184110-565402cd71fb
 	github.com/mailgun/timetools v0.0.0-20141028012446-7e6055773c51
 	github.com/mailgun/ttlmap v0.0.0-20170619185759-c1c17f74874f
+	github.com/segmentio/fasthash v1.0.3
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.5.1
 	github.com/vulcand/predicate v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/mailgun/ttlmap v0.0.0-20170619185759-c1c17f74874f h1:ZZYhg16XocqSKPGN
 github.com/mailgun/ttlmap v0.0.0-20170619185759-c1c17f74874f/go.mod h1:8heskWJ5c0v5J9WH89ADhyal1DOZcayll8fSbhB+/9A=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/segmentio/fasthash v1.0.3 h1:EI9+KE1EwvMLBWwjpRDc+fEM+prwxDYbslddQGtrmhM=
+github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/roundrobin/stickycookie/aes_value.go
+++ b/roundrobin/stickycookie/aes_value.go
@@ -1,0 +1,138 @@
+package stickycookie
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// AESValue manages hashed sticky value.
+type AESValue struct {
+	block cipher.AEAD
+	ttl   time.Duration
+}
+
+// NewAESValue takes a fixed-size key and returns an CookieValue or an error.
+// Key size must be exactly one of 16, 24, or 32 bytes to select AES-128, AES-192, or AES-256.
+func NewAESValue(key []byte, ttl time.Duration) (*AESValue, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	return &AESValue{block: gcm, ttl: ttl}, nil
+}
+
+// Get hashes the sticky value.
+func (v *AESValue) Get(raw *url.URL) string {
+	base := raw.String()
+	if v.ttl > 0 {
+		base = fmt.Sprintf("%s|%d", base, time.Now().UTC().Add(v.ttl).Unix())
+	}
+
+	// Nonce is the 64bit nanosecond-resolution time, plus 32bits of crypto/rand, for 96bits (12Bytes).
+	// Theoretically, if 2^32 calls were made in 1 nanoseconds, there might be a repeat.
+	// Adds ~765ns, and 4B heap in 1 alloc
+	nonce := make([]byte, 12)
+	binary.PutVarint(nonce, time.Now().UnixNano())
+
+	rpend := make([]byte, 4)
+	if _, err := io.ReadFull(rand.Reader, rpend); err != nil {
+		// This is a near-impossible error condition on Linux systems.
+		// An error here means rand.Reader (and thus getrandom(2), and thus /dev/urandom) returned
+		// less than 4 bytes of data. /dev/urandom is guaranteed to always return the number of
+		// bytes requested up to 512 bytes on modern kernels. Behaviour on non-Linux systems
+		// varies, of course.
+		panic(err)
+	}
+
+	for i := 0; i < 4; i++ {
+		nonce[i+8] = rpend[i]
+	}
+
+	obfuscated := v.block.Seal(nil, nonce, []byte(base), nil)
+	// We append the 12byte nonce onto the end of the message
+	obfuscated = append(obfuscated, nonce...)
+	obfuscatedStr := base64.RawURLEncoding.EncodeToString(obfuscated)
+
+	return obfuscatedStr
+}
+
+// FindURL gets url from array that match the value.
+func (v *AESValue) FindURL(raw string, urls []*url.URL) (*url.URL, error) {
+	rawURL, err := v.fromValue(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, u := range urls {
+		ok, err := areURLEqual(rawURL, u)
+		if err != nil {
+			return nil, err
+		}
+
+		if ok {
+			return u, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func (v *AESValue) fromValue(obfuscatedStr string) (string, error) {
+	obfuscated, err := base64.RawURLEncoding.DecodeString(obfuscatedStr)
+	if err != nil {
+		return "", err
+	}
+
+	// The first len-12 bytes is the ciphertext, the last 12 bytes is the nonce
+	n := len(obfuscated) - 12
+	if n <= 0 {
+		// Protect against range errors causing panics
+		return "", errors.New("post-base64-decoded string is too short")
+	}
+
+	nonce := obfuscated[n:]
+	obfuscated = obfuscated[:n]
+
+	raw, err := v.block.Open(nil, nonce, []byte(obfuscated), nil)
+	if err != nil {
+		return "", err
+	}
+
+	if v.ttl > 0 {
+		rawParts := strings.Split(string(raw), "|")
+		if len(rawParts) < 2 {
+			return "", fmt.Errorf("TTL set but cookie doesn't contain an expiration: '%s'", raw)
+		}
+
+		// validate the ttl
+		i, err := strconv.ParseInt(rawParts[1], 10, 64)
+		if err != nil {
+			return "", err
+		}
+
+		if time.Now().UTC().After(time.Unix(i, 0).UTC()) {
+			strTime := time.Unix(i, 0).UTC().String()
+			return "", fmt.Errorf("TTL expired: '%s' (%s)\n", raw, strTime)
+		}
+
+		raw = []byte(rawParts[0])
+	}
+
+	return string(raw), nil
+}

--- a/roundrobin/stickycookie/cookie_value.go
+++ b/roundrobin/stickycookie/cookie_value.go
@@ -1,0 +1,23 @@
+package stickycookie
+
+import "net/url"
+
+// CookieValue interface to manage the sticky cookie value format.
+// It will be used by the load balancer to generate the sticky cookie value and to retrieve the matching url.
+type CookieValue interface {
+	// Get converts raw value to an expected sticky format.
+	Get(*url.URL) string
+
+	// FindURL gets url from array that match the value.
+	FindURL(string, []*url.URL) (*url.URL, error)
+}
+
+// areURLEqual compare a string to a url and check if the string is the same as the url value.
+func areURLEqual(normalized string, u *url.URL) (bool, error) {
+	u1, err := url.Parse(normalized)
+	if err != nil {
+		return false, err
+	}
+
+	return u1.Scheme == u.Scheme && u1.Host == u.Host && u1.Path == u.Path, nil
+}

--- a/roundrobin/stickycookie/fallback_value.go
+++ b/roundrobin/stickycookie/fallback_value.go
@@ -1,0 +1,37 @@
+package stickycookie
+
+import (
+	"errors"
+	"net/url"
+)
+
+// FallbackValue manages hashed sticky value.
+type FallbackValue struct {
+	from CookieValue
+	to   CookieValue
+}
+
+// NewFallbackValue creates a new FallbackValue
+func NewFallbackValue(from CookieValue, to CookieValue) (*FallbackValue, error) {
+	if from == nil || to == nil {
+		return nil, errors.New("from and to are mandatory")
+	}
+
+	return &FallbackValue{from: from, to: to}, nil
+}
+
+// Get hashes the sticky value.
+func (v *FallbackValue) Get(raw *url.URL) string {
+	return v.to.Get(raw)
+}
+
+// FindURL gets url from array that match the value.
+// If it is a symmetric algorithm, it decodes the URL, otherwise it compares the ciphered values.
+func (v *FallbackValue) FindURL(raw string, urls []*url.URL) (*url.URL, error) {
+	findURL, err := v.from.FindURL(raw, urls)
+	if findURL != nil {
+		return findURL, err
+	}
+
+	return v.to.FindURL(raw, urls)
+}

--- a/roundrobin/stickycookie/fallback_value_test.go
+++ b/roundrobin/stickycookie/fallback_value_test.go
@@ -1,0 +1,219 @@
+package stickycookie
+
+import (
+	"fmt"
+	"net/url"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFallbackValue_FindURL(t *testing.T) {
+	servers := []*url.URL{
+		{Scheme: "https", Host: "10.10.10.42", Path: "/"},
+		{Scheme: "http", Host: "10.10.10.10", Path: "/foo"},
+		{Scheme: "http", Host: "10.10.10.11", Path: "/", User: url.User("John Doe")},
+		{Scheme: "http", Host: "10.10.10.10", Path: "/"},
+	}
+
+	aesValue, err := NewAESValue([]byte("95Bx9JkKX3xbd7z3"), 5*time.Second)
+	require.NoError(t, err)
+
+	values := []struct {
+		Name        string
+		CookieValue CookieValue
+	}{
+		{Name: "rawValue", CookieValue: &RawValue{}},
+		{Name: "hashValue", CookieValue: &HashValue{Salt: "foo"}},
+		{Name: "aesValue", CookieValue: aesValue},
+	}
+
+	for _, from := range values {
+		from := from
+		for _, to := range values {
+			to := to
+			t.Run(fmt.Sprintf("From: %s, To %s", from.Name, to.Name), func(t *testing.T) {
+				t.Parallel()
+
+				value, err := NewFallbackValue(from.CookieValue, to.CookieValue)
+				if from.CookieValue == nil && to.CookieValue == nil {
+					assert.Error(t, err)
+					return
+				}
+				require.NoError(t, err)
+
+				if from.CookieValue != nil {
+					// URL found From value
+					findURL, err := value.FindURL(from.CookieValue.Get(servers[0]), servers)
+					require.NoError(t, err)
+					assert.Equal(t, servers[0], findURL)
+
+					// URL not found From value
+					findURL, _ = value.FindURL(from.CookieValue.Get(mustJoin(t, servers[0], "bar")), servers)
+					assert.Nil(t, findURL)
+				}
+
+				if to.CookieValue != nil {
+					// URL found To Value
+					findURL, err := value.FindURL(to.CookieValue.Get(servers[0]), servers)
+					require.NoError(t, err)
+					assert.Equal(t, servers[0], findURL)
+
+					// URL not found To value
+					findURL, _ = value.FindURL(to.CookieValue.Get(mustJoin(t, servers[0], "bar")), servers)
+					assert.Nil(t, findURL)
+				}
+			})
+		}
+	}
+}
+
+func TestFallbackValue_FindURL_error(t *testing.T) {
+	servers := []*url.URL{
+		{Scheme: "http", Host: "10.10.10.10", Path: "/"},
+		{Scheme: "https", Host: "10.10.10.42", Path: "/"},
+		{Scheme: "http", Host: "10.10.10.10", Path: "/foo"},
+		{Scheme: "http", Host: "10.10.10.11", Path: "/", User: url.User("John Doe")},
+	}
+
+	hashValue := &HashValue{Salt: "foo"}
+	rawValue := &RawValue{}
+	aesValue, err := NewAESValue([]byte("95Bx9JkKX3xbd7z3"), 5*time.Second)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name             string
+		From             CookieValue
+		To               CookieValue
+		rawValue         string
+		want             *url.URL
+		expectError      bool
+		expectErrorOnNew bool
+	}{
+		{
+			name:     "From RawValue To HashValue with RawValue value",
+			From:     rawValue,
+			To:       hashValue,
+			rawValue: "http://10.10.10.10/",
+			want:     servers[0],
+		},
+		{
+			name:     "From RawValue To HashValue with RawValue non matching value",
+			From:     rawValue,
+			To:       hashValue,
+			rawValue: "http://24.10.10.10/",
+		},
+		{
+			name:     "From RawValue To HashValue with HashValue value",
+			From:     rawValue,
+			To:       hashValue,
+			rawValue: hashValue.Get(mustParse(t, "http://10.10.10.10/")),
+			want:     servers[0],
+		},
+		{
+			name:     "From RawValue To HashValue with HashValue non matching value",
+			From:     rawValue,
+			To:       hashValue,
+			rawValue: hashValue.Get(mustParse(t, "http://24.10.10.10/")),
+		},
+		{
+			name:     "From HashValue To AESValue with AESValue value",
+			From:     hashValue,
+			To:       aesValue,
+			rawValue: aesValue.Get(mustParse(t, "http://10.10.10.10/")),
+			want:     servers[0],
+		},
+		{
+			name:     "From HashValue To AESValue with AESValue non matching value",
+			From:     hashValue,
+			To:       aesValue,
+			rawValue: aesValue.Get(mustParse(t, "http://24.10.10.10/")),
+		},
+		{
+			name:     "From HashValue To AESValue with HashValue value",
+			From:     hashValue,
+			To:       aesValue,
+			rawValue: hashValue.Get(mustParse(t, "http://10.10.10.10/")),
+			want:     servers[0],
+		},
+		{
+			name:     "From HashValue To AESValue with AESValue non matching value",
+			From:     hashValue,
+			To:       aesValue,
+			rawValue: aesValue.Get(mustParse(t, "http://24.10.10.10/")),
+		},
+		{
+			name:     "From AESValue To AESValue with AESValue value",
+			From:     aesValue,
+			To:       aesValue,
+			rawValue: aesValue.Get(mustParse(t, "http://10.10.10.10/")),
+			want:     servers[0],
+		},
+		{
+			name:     "From AESValue To AESValue with AESValue non matching value",
+			From:     aesValue,
+			To:       aesValue,
+			rawValue: aesValue.Get(mustParse(t, "http://24.10.10.10/")),
+		},
+		{
+			name:     "From AESValue To HashValue with HashValue non matching value",
+			From:     aesValue,
+			To:       hashValue,
+			rawValue: hashValue.Get(mustParse(t, "http://24.10.10.10/")),
+		},
+		{
+			name:             "From nil To RawValue",
+			To:               hashValue,
+			rawValue:         "http://24.10.10.10/",
+			expectErrorOnNew: true,
+		},
+		{
+			name:             "From RawValue To nil",
+			From:             rawValue,
+			rawValue:         "http://24.10.10.10/",
+			expectErrorOnNew: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value, err := NewFallbackValue(tt.From, tt.To)
+			if tt.expectErrorOnNew {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			findURL, err := value.FindURL(tt.rawValue, servers)
+			if tt.expectError {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.want, findURL)
+		})
+	}
+}
+
+func mustJoin(t *testing.T, u *url.URL, part string) *url.URL {
+	t.Helper()
+
+	nu, err := u.Parse(path.Join(u.Path, part))
+	require.NoError(t, err)
+
+	return nu
+}
+
+func mustParse(t *testing.T, raw string) *url.URL {
+	t.Helper()
+
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+
+	return u
+}

--- a/roundrobin/stickycookie/hash_value.go
+++ b/roundrobin/stickycookie/hash_value.go
@@ -1,0 +1,39 @@
+package stickycookie
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/segmentio/fasthash/fnv1a"
+)
+
+// HashValue manages hashed sticky value.
+type HashValue struct {
+	// Salt secret to anonymize the hashed cookie
+	Salt string
+}
+
+// Get hashes the sticky value.
+func (v *HashValue) Get(raw *url.URL) string {
+	return v.hash(raw.String())
+}
+
+// FindURL gets url from array that match the value.
+func (v *HashValue) FindURL(raw string, urls []*url.URL) (*url.URL, error) {
+	for _, u := range urls {
+		if raw == v.hash(normalized(u)) {
+			return u, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func (v *HashValue) hash(input string) string {
+	return fmt.Sprintf("%x", fnv1a.HashString64(v.Salt+input))
+}
+
+func normalized(u *url.URL) string {
+	normalized := url.URL{Scheme: u.Scheme, Host: u.Host, Path: u.Path}
+	return normalized.String()
+}

--- a/roundrobin/stickycookie/raw_value.go
+++ b/roundrobin/stickycookie/raw_value.go
@@ -1,0 +1,29 @@
+package stickycookie
+
+import (
+	"net/url"
+)
+
+// RawValue is a no-op that returns the raw strings as-is.
+type RawValue struct{}
+
+// Get returns the raw value.
+func (v *RawValue) Get(raw *url.URL) string {
+	return raw.String()
+}
+
+// FindURL gets url from array that match the value.
+func (v *RawValue) FindURL(raw string, urls []*url.URL) (*url.URL, error) {
+	for _, u := range urls {
+		ok, err := areURLEqual(raw, u)
+		if err != nil {
+			return nil, err
+		}
+
+		if ok {
+			return u, nil
+		}
+	}
+
+	return nil, nil
+}

--- a/roundrobin/stickysessions.go
+++ b/roundrobin/stickysessions.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 	"net/url"
 	"time"
+
+	"github.com/vulcand/oxy/roundrobin/stickycookie"
 )
 
 // CookieOptions has all the options one would like to set on the affinity cookie
@@ -21,19 +23,26 @@ type CookieOptions struct {
 
 // StickySession is a mixin for load balancers that implements layer 7 (http cookie) session affinity
 type StickySession struct {
-	cookieName string
-	options    CookieOptions
+	cookieName  string
+	cookieValue stickycookie.CookieValue
+	options     CookieOptions
 }
 
 // NewStickySession creates a new StickySession
 func NewStickySession(cookieName string) *StickySession {
-	return &StickySession{cookieName: cookieName}
+	return &StickySession{cookieName: cookieName, cookieValue: &stickycookie.RawValue{}}
 }
 
 // NewStickySessionWithOptions creates a new StickySession whilst allowing for options to
 // shape its affinity cookie such as "httpOnly" or "secure"
 func NewStickySessionWithOptions(cookieName string, options CookieOptions) *StickySession {
-	return &StickySession{cookieName: cookieName, options: options}
+	return &StickySession{cookieName: cookieName, options: options, cookieValue: &stickycookie.RawValue{}}
+}
+
+// SetCookieValue set the CookieValue for the StickySession.
+func (s *StickySession) SetCookieValue(value stickycookie.CookieValue) *StickySession {
+	s.cookieValue = value
+	return s
 }
 
 // GetBackend returns the backend URL stored in the sticky cookie, iff the backend is still in the valid list of servers.
@@ -47,15 +56,9 @@ func (s *StickySession) GetBackend(req *http.Request, servers []*url.URL) (*url.
 		return nil, false, err
 	}
 
-	serverURL, err := url.Parse(cookie.Value)
-	if err != nil {
-		return nil, false, err
-	}
+	server, err := s.cookieValue.FindURL(cookie.Value, servers)
 
-	if s.isBackendAlive(serverURL, servers) {
-		return serverURL, true, nil
-	}
-	return nil, false, nil
+	return server, server != nil, err
 }
 
 // StickBackend creates and sets the cookie
@@ -69,7 +72,7 @@ func (s *StickySession) StickBackend(backend *url.URL, w *http.ResponseWriter) {
 
 	cookie := &http.Cookie{
 		Name:     s.cookieName,
-		Value:    backend.String(),
+		Value:    s.cookieValue.Get(backend),
 		Path:     cp,
 		Domain:   opt.Domain,
 		Expires:  opt.Expires,
@@ -79,17 +82,4 @@ func (s *StickySession) StickBackend(backend *url.URL, w *http.ResponseWriter) {
 		SameSite: opt.SameSite,
 	}
 	http.SetCookie(*w, cookie)
-}
-
-func (s *StickySession) isBackendAlive(needle *url.URL, haystack []*url.URL) bool {
-	if len(haystack) == 0 {
-		return false
-	}
-
-	for _, serverURL := range haystack {
-		if sameURL(needle, serverURL) {
-			return true
-		}
-	}
-	return false
 }

--- a/roundrobin/stickysessions_test.go
+++ b/roundrobin/stickysessions_test.go
@@ -5,12 +5,14 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vulcand/oxy/forward"
+	"github.com/vulcand/oxy/roundrobin/stickycookie"
 	"github.com/vulcand/oxy/testutils"
 )
 
@@ -53,6 +55,116 @@ func TestBasic(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, "a", string(body))
+	}
+}
+
+func TestBasicWithHashValue(t *testing.T) {
+	a := testutils.NewResponder("a")
+	b := testutils.NewResponder("b")
+
+	defer a.Close()
+	defer b.Close()
+
+	fwd, err := forward.New()
+	require.NoError(t, err)
+
+	sticky := NewStickySession("test")
+	require.NotNil(t, sticky)
+
+	sticky.SetCookieValue(&stickycookie.HashValue{Salt: "foo"})
+	require.NotNil(t, sticky.cookieValue)
+
+	lb, err := New(fwd, EnableStickySession(sticky))
+	require.NoError(t, err)
+
+	err = lb.UpsertServer(testutils.ParseURI(a.URL))
+	require.NoError(t, err)
+	err = lb.UpsertServer(testutils.ParseURI(b.URL))
+	require.NoError(t, err)
+
+	proxy := httptest.NewServer(lb)
+	defer proxy.Close()
+
+	client := http.DefaultClient
+	var cookie *http.Cookie
+	for i := 0; i < 10; i++ {
+		req, err := http.NewRequest(http.MethodGet, proxy.URL, nil)
+		require.NoError(t, err)
+		if cookie != nil {
+			req.AddCookie(cookie)
+		}
+
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+
+		body, err := ioutil.ReadAll(resp.Body)
+		defer resp.Body.Close()
+
+		require.NoError(t, err)
+		assert.Equal(t, "a", string(body))
+
+		if cookie == nil {
+			// The first request will set the cookie value
+			cookie = resp.Cookies()[0]
+		}
+		assert.Equal(t, "test", cookie.Name)
+		assert.Equal(t, sticky.cookieValue.Get(mustParse(t, a.URL)), cookie.Value)
+	}
+}
+
+func TestBasicWithAESValue(t *testing.T) {
+	a := testutils.NewResponder("a")
+	b := testutils.NewResponder("b")
+
+	defer a.Close()
+	defer b.Close()
+
+	fwd, err := forward.New()
+	require.NoError(t, err)
+
+	sticky := NewStickySession("test")
+	require.NotNil(t, sticky)
+
+	aesValue, err := stickycookie.NewAESValue([]byte("95Bx9JkKX3xbd7z3"), 5*time.Second)
+	require.NoError(t, err)
+
+	sticky.SetCookieValue(aesValue)
+	require.NotNil(t, sticky.cookieValue)
+
+	lb, err := New(fwd, EnableStickySession(sticky))
+	require.NoError(t, err)
+
+	err = lb.UpsertServer(testutils.ParseURI(a.URL))
+	require.NoError(t, err)
+	err = lb.UpsertServer(testutils.ParseURI(b.URL))
+	require.NoError(t, err)
+
+	proxy := httptest.NewServer(lb)
+	defer proxy.Close()
+
+	client := http.DefaultClient
+	var cookie *http.Cookie
+	for i := 0; i < 10; i++ {
+		req, err := http.NewRequest(http.MethodGet, proxy.URL, nil)
+		require.NoError(t, err)
+		if cookie != nil {
+			req.AddCookie(cookie)
+		}
+
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+
+		body, err := ioutil.ReadAll(resp.Body)
+		defer resp.Body.Close()
+
+		require.NoError(t, err)
+		assert.Equal(t, "a", string(body))
+
+		if cookie == nil {
+			// The first request will set the cookie value
+			cookie = resp.Cookies()[0]
+		}
+		assert.Equal(t, "test", cookie.Name)
 	}
 }
 
@@ -410,4 +522,165 @@ func TestBadCookieVal(t *testing.T) {
 	_, err = ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+}
+
+func TestStickySession_GetBackend(t *testing.T) {
+	cookieName := "Test-Cookie"
+
+	servers := []*url.URL{
+		{Scheme: "http", Host: "10.10.10.10", Path: "/"},
+		{Scheme: "https", Host: "10.10.10.42", Path: "/"},
+		{Scheme: "http", Host: "10.10.10.10", Path: "/foo"},
+		{Scheme: "http", Host: "10.10.10.11", Path: "/", User: url.User("John Doe")},
+	}
+
+	rawValue := &stickycookie.RawValue{}
+	hashValue := &stickycookie.HashValue{}
+	saltyHashValue := &stickycookie.HashValue{Salt: "test salt"}
+	aesValue, err := stickycookie.NewAESValue([]byte("95Bx9JkKX3xbd7z3"), 5*time.Second)
+	aesValueInfinite, err := stickycookie.NewAESValue([]byte("95Bx9JkKX3xbd7z3"), 0)
+	require.NoError(t, err)
+	aesValueExpired, err := stickycookie.NewAESValue([]byte("95Bx9JkKX3xbd7z3"), 1*time.Nanosecond)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		CookieValue stickycookie.CookieValue
+		cookie      *http.Cookie
+		want        *url.URL
+		expectError bool
+	}{
+		{
+			name: "NoCookies",
+		},
+		{
+			name:   "Cookie no matched",
+			cookie: &http.Cookie{Name: "not" + cookieName, Value: "http://10.10.10.10/"},
+		},
+		{
+			name:        "Cookie not a URL",
+			cookie:      &http.Cookie{Name: cookieName, Value: "foo://foo bar"},
+			expectError: true,
+		},
+		{
+			name:   "Simple",
+			cookie: &http.Cookie{Name: cookieName, Value: "http://10.10.10.10/"},
+			want:   servers[0],
+		},
+		{
+			name:   "Host no match for needle",
+			cookie: &http.Cookie{Name: cookieName, Value: "http://10.10.10.255/"},
+		},
+		{
+			name:   "Scheme no match for needle",
+			cookie: &http.Cookie{Name: cookieName, Value: "https://10.10.10.10/"},
+		},
+		{
+			name:   "Path no match for needle",
+			cookie: &http.Cookie{Name: cookieName, Value: "http://10.10.10.10/foo/bar"},
+		},
+		{
+			name:   "With user in haystack but not in needle",
+			cookie: &http.Cookie{Name: cookieName, Value: "http://10.10.10.11/"},
+			want:   servers[3],
+		},
+		{
+			name:   "With user in haystack and in needle",
+			cookie: &http.Cookie{Name: cookieName, Value: "http://John%20Doe@10.10.10.11/"},
+			want:   servers[3],
+		},
+		{
+			name:        "Cookie no matched with RawValue",
+			CookieValue: rawValue,
+			cookie:      &http.Cookie{Name: "not" + cookieName, Value: rawValue.Get(mustParse(t, "http://10.10.10.10/"))},
+		},
+		{
+			name:        "Cookie no matched with HashValue",
+			CookieValue: hashValue,
+			cookie:      &http.Cookie{Name: "not" + cookieName, Value: hashValue.Get(mustParse(t, "http://10.10.10.10/"))},
+		},
+		{
+			name:        "Cookie value not matched with HashValue",
+			CookieValue: hashValue,
+			cookie:      &http.Cookie{Name: cookieName, Value: hashValue.Get(mustParse(t, "http://10.10.10.255/"))},
+		},
+		{
+			name:        "simple with HashValue",
+			CookieValue: hashValue,
+			cookie:      &http.Cookie{Name: cookieName, Value: hashValue.Get(mustParse(t, "http://10.10.10.10/"))},
+			want:        servers[0],
+		},
+		{
+			name:        "simple with HashValue and salt",
+			CookieValue: saltyHashValue,
+			cookie:      &http.Cookie{Name: cookieName, Value: saltyHashValue.Get(mustParse(t, "http://10.10.10.10/"))},
+			want:        servers[0],
+		},
+		{
+			name:        "Cookie value not matched with AESValue",
+			CookieValue: aesValue,
+			cookie:      &http.Cookie{Name: cookieName, Value: aesValue.Get(mustParse(t, "http://10.10.10.255/"))},
+		},
+		{
+			name:        "simple with AESValue",
+			CookieValue: aesValue,
+			cookie:      &http.Cookie{Name: cookieName, Value: aesValue.Get(mustParse(t, "http://10.10.10.10/"))},
+			want:        servers[0],
+		},
+		{
+			name:        "Cookie value not matched with AESValue with ttl 0s",
+			CookieValue: aesValueInfinite,
+			cookie:      &http.Cookie{Name: cookieName, Value: aesValueInfinite.Get(mustParse(t, "http://10.10.10.255/"))},
+		},
+		{
+			name:        "simple with AESValue with ttl 0s",
+			CookieValue: aesValueInfinite,
+			cookie:      &http.Cookie{Name: cookieName, Value: aesValueInfinite.Get(mustParse(t, "http://10.10.10.10/"))},
+			want:        servers[0],
+		},
+		{
+			name:        "simple with AESValue with ttl 0s",
+			CookieValue: aesValueInfinite,
+			cookie:      &http.Cookie{Name: cookieName, Value: aesValueInfinite.Get(mustParse(t, "http://10.10.10.10/"))},
+			want:        servers[0],
+		},
+		{
+			name:        "simple with AESValue with expired ttl",
+			CookieValue: aesValueExpired,
+			cookie:      &http.Cookie{Name: cookieName, Value: aesValueExpired.Get(mustParse(t, "http://10.10.10.10/"))},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewStickySession(cookieName)
+			if tt.CookieValue != nil {
+				s.SetCookieValue(tt.CookieValue)
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "http://foo", nil)
+			if tt.cookie != nil {
+				req.AddCookie(tt.cookie)
+			}
+
+			got, _, err := s.GetBackend(req, servers)
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func mustParse(t *testing.T, raw string) *url.URL {
+	t.Helper()
+
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+
+	return u
 }


### PR DESCRIPTION
### What does this PR do?

Add a mechanism to format the sticky cookie value.
It introduces a `CookieValue` interface to allow implementations to control the sticky cookie value.

There are several implementations available:
- `RawValue`: no operation - keep the cookie value as it is. (used by default)
- `HashValue`: hash the cookie value with a fast hash algorithm.
- `AESValue`: ciphers the cookie value with an AES algorithm.
- `FallbackValue`: try to apply a value transformation and fallback to another. Useful to migrate from one value to another.

### Motivation

This PR is inspired by #184 and #203 and provides a flexible way to manage the cookie value and some basic implementations.
 
closes #184 
closes #203

### Additional Notes

Co-authored-by: Tom Moulard <tom.moulard@traefik.io>
Co-authored-by: M <m@cognusion.com>
Co-authored-by: Sylvain Rabot <sylvain@abstraction.fr>
