### PR TITLE
Add Websocket Hooks

### DIFF
--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -275,7 +275,9 @@ func New(setters ...optSetter) (*Forwarder, error) {
 		if ht, ok := f.httpForwarder.roundTripper.(*http.Transport); ok {
 			f.tlsClientConfig = ht.TLSClientConfig
 			if f.websocketDialer.TLSClientConfig == nil && ht.TLSClientConfig != nil {
-				_ = WebsocketTLSClientConfig(ht.TLSClientConfig)(f)
+				if err := WebsocketTLSClientConfig(ht.TLSClientConfig)(f); err != nil {
+					return f, err
+				}
 			}
 		}
 	}

--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -43,7 +43,7 @@ type ReqRewriter interface {
 	Rewrite(r *http.Request)
 }
 
-// WsHook websocket message hook called when message is received or sent
+// WsHook websocket message hook called when message is received or sent.
 type WsHook func(req *http.Request, messageType int, reader io.Reader) (io.Reader, error)
 
 type optSetter func(f *Forwarder) error
@@ -84,7 +84,7 @@ func WebsocketTLSClientConfig(tcc *tls.Config) optSetter {
 	}
 }
 
-// WebsocketNetDialContext define the websocket client DialContext function
+// WebsocketNetDialContext define the websocket client DialContext function.
 func WebsocketNetDialContext(dialContext func(ctx context.Context, network string, addr string) (net.Conn, error)) optSetter {
 	return func(f *Forwarder) error {
 		f.websocketDialer.NetDialContext = dialContext
@@ -151,7 +151,7 @@ func WebsocketConnectionClosedHook(hook func(req *http.Request, conn net.Conn)) 
 	}
 }
 
-// WebsocketMessageReceivedHook defines a hook called when websocket message is received
+// WebsocketMessageReceivedHook defines a hook called when websocket message is received.
 func WebsocketMessageReceivedHook(hook WsHook) optSetter {
 	return func(f *Forwarder) error {
 		f.httpForwarder.websocketMessageReceivedHook = hook
@@ -159,7 +159,7 @@ func WebsocketMessageReceivedHook(hook WsHook) optSetter {
 	}
 }
 
-// WebsocketMessageSentHook defines a hook called when websocket message is sent
+// WebsocketMessageSentHook defines a hook called when websocket message is sent.
 func WebsocketMessageSentHook(hook WsHook) optSetter {
 	return func(f *Forwarder) error {
 		f.httpForwarder.websocketMessageSentHook = hook
@@ -205,7 +205,7 @@ type httpForwarder struct {
 	flushInterval  time.Duration
 	modifyResponse func(*http.Response) error
 
-	tlsClientConfig *tls.Config
+	tlsClientConfig *tls.Config //nolint:structcheck // used via embed in Forwarder
 
 	log OxyLogger
 

--- a/forward/fwd_websocket_test.go
+++ b/forward/fwd_websocket_test.go
@@ -695,7 +695,11 @@ func TestWebSocketTransferTLSConfig(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "ok", resp)
 
+	priorTLS := http.DefaultTransport.(*http.Transport).TLSClientConfig
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	defer func() {
+		http.DefaultTransport.(*http.Transport).TLSClientConfig = priorTLS
+	}()
 
 	forwarderWithTLSConfigFromDefaultTransport, err := New(PassHostHeader(true))
 	require.NoError(t, err)

--- a/forward/fwd_websocket_test.go
+++ b/forward/fwd_websocket_test.go
@@ -276,6 +276,7 @@ func TestWebSocketPassHost(t *testing.T) {
 }
 
 func TestWebSocketNumGoRoutine(t *testing.T) {
+	t.Skip("Flaky on goroutine")
 	f, err := New()
 	require.NoError(t, err)
 

--- a/forward/fwd_websocket_test.go
+++ b/forward/fwd_websocket_test.go
@@ -276,7 +276,6 @@ func TestWebSocketPassHost(t *testing.T) {
 }
 
 func TestWebSocketNumGoRoutine(t *testing.T) {
-	t.Skip("Flaky on goroutine")
 	f, err := New()
 	require.NoError(t, err)
 


### PR DESCRIPTION
This is an attempt to port the changes on our fork into the main repo.

This adds a few options:
* WebsocketNetDialContext - Allows specifying the gorilla.Dialer NetDialContext - https://pkg.go.dev/github.com/gorilla/websocket#Dialer
* WebsocketMessageReceivedHook & WebsocketMessageSentHook - Allows specifying a hook that will be called with a websocket message is received or sent.