### PR TITLE
Introduce NewHeaderRewriter function.

### DIFF
--- a/forward/fwd.go
+++ b/forward/fwd.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
-	"os"
 	"reflect"
 	"strings"
 	"time"
@@ -216,11 +215,7 @@ func New(setters ...optSetter) (*Forwarder, error) {
 	}
 
 	if f.httpForwarder.rewriter == nil {
-		h, err := os.Hostname()
-		if err != nil {
-			h = "localhost"
-		}
-		f.httpForwarder.rewriter = &HeaderRewriter{TrustForwardHeader: true, Hostname: h}
+		f.httpForwarder.rewriter = NewHeaderRewriter(true)
 	}
 
 	if f.httpForwarder.roundTripper == nil {

--- a/forward/rewrite.go
+++ b/forward/rewrite.go
@@ -3,6 +3,7 @@ package forward
 import (
 	"net"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/vulcand/oxy/utils"
@@ -12,6 +13,15 @@ import (
 type HeaderRewriter struct {
 	TrustForwardHeader bool
 	Hostname           string
+}
+
+// NewHeaderRewriter creates a new header rewriter with sane defaults.
+func NewHeaderRewriter(trustForwardHeader bool) *HeaderRewriter {
+	h, err := os.Hostname()
+	if err != nil {
+		h = "localhost"
+	}
+	return &HeaderRewriter{TrustForwardHeader: trustForwardHeader, Hostname: h}
 }
 
 // clean up IP in case if it is ipv6 address and it has {zone} information in it, like "[fe80::d806:a55d:eb1b:49cc%vEthernet (vmxnet3 Ethernet Adapter - Virtual Switch)]:64692".


### PR DESCRIPTION
A utility function called NewHeaderRewriter has been added so that callers can create a HeaderRewriter with oxy's built in hostname logic and customize the TrustForwardHeader setting.