### PR TITLE
buffer: fix typo in hijack algorithm

### DIFF
--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -410,12 +410,12 @@ func (b *bufferWriter) CloseNotify() <-chan bool {
 func (b *bufferWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	if hi, ok := b.responseWriter.(http.Hijacker); ok {
 		conn, rw, err := hi.Hijack()
-		if err != nil {
+		if err == nil {
 			b.hijacked = true
 		}
 		return conn, rw, err
 	}
-	b.log.Warningf("Upstream ResponseWriter of type %v does not implement http.Hijacker. Returning dummy channel.", reflect.TypeOf(b.responseWriter))
+	b.log.Warningf("Upstream ResponseWriter of type %v does not implement http.Hijacker.", reflect.TypeOf(b.responseWriter))
 	return nil, nil, fmt.Errorf("the response writer wrapped in this proxy does not implement http.Hijacker. Its type is: %v", reflect.TypeOf(b.responseWriter))
 }
 


### PR DESCRIPTION
### What does this PR do?

This pull request fixes a typo in the `Hijack` algorithm. The hijack boolean must be set to `true` when the connection is hijacked not the opposite. This allows disabling buffering for hijacked connections (see https://github.com/vulcand/oxy/blob/master/buffer/buffer.go#L282). 

### Additional Notes

Co-authored-by: Mathieu Lonjaret <mathieu.lonjaret@gmail.com>