### PR TITLE
fix(memmetrics): prevent 'now' from accumulating during cleanup

### DIFF
--- a/memmetrics/counter.go
+++ b/memmetrics/counter.go
@@ -131,9 +131,9 @@ func (c *RollingCounter) getBucket(t time.Time) int {
 func (c *RollingCounter) cleanup() {
 	now := clock.Now().UTC()
 	for i := 0; i < len(c.values); i++ {
-		now = now.Add(time.Duration(-1*i) * c.resolution)
-		if now.Truncate(c.resolution).After(c.lastUpdated.Truncate(c.resolution)) {
-			c.values[c.getBucket(now)] = 0
+		checkPoint := now.Add(time.Duration(-1*i) * c.resolution)
+		if checkPoint.Truncate(c.resolution).After(c.lastUpdated.Truncate(c.resolution)) {
+			c.values[c.getBucket(checkPoint)] = 0
 		} else {
 			break
 		}

--- a/memmetrics/counter_test.go
+++ b/memmetrics/counter_test.go
@@ -27,3 +27,22 @@ func TestCloneExpired(t *testing.T) {
 
 	assert.EqualValues(t, 2, out.Count())
 }
+
+func TestCleanup(t *testing.T) {
+	clock.Freeze(clock.Date(2012, 3, 4, 5, 6, 7, 0, clock.UTC))
+
+	cnt, err := NewCounter(10, clock.Second)
+	require.NoError(t, err)
+
+	cnt.Inc(1)
+	for i := 0; i < 9; i++ {
+		clock.Advance(clock.Second)
+		cnt.Inc(1)
+	}
+	// cnt will be  [1 1 1 1 1 1 1 1 1 1]
+
+	clock.Advance(9 * clock.Second)
+	assert.EqualValues(t, 1, cnt.Count())
+	// cnt will be  [0 0 0 0 0 0 1 0 0 0]
+	// old behavior [1 1 0 1 0 0 1 1 1 0]
+}

--- a/memmetrics/counter_test.go
+++ b/memmetrics/counter_test.go
@@ -1,6 +1,7 @@
 package memmetrics
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,21 +29,24 @@ func TestCloneExpired(t *testing.T) {
 	assert.EqualValues(t, 2, out.Count())
 }
 
-func TestCleanup(t *testing.T) {
+func Test_cleanup(t *testing.T) {
 	clock.Freeze(clock.Date(2012, 3, 4, 5, 6, 7, 0, clock.UTC))
 
 	cnt, err := NewCounter(10, clock.Second)
 	require.NoError(t, err)
 
 	cnt.Inc(1)
+
 	for i := 0; i < 9; i++ {
 		clock.Advance(clock.Second)
-		cnt.Inc(1)
+		cnt.Inc(int(math.Pow10(i + 1)))
 	}
-	// cnt will be  [1 1 1 1 1 1 1 1 1 1]
+
+	assert.EqualValues(t, 1111111111, cnt.Count())
+	assert.Equal(t, []int{1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000, 1, 10, 100}, cnt.values)
 
 	clock.Advance(9 * clock.Second)
-	assert.EqualValues(t, 1, cnt.Count())
-	// cnt will be  [0 0 0 0 0 0 1 0 0 0]
-	// old behavior [1 1 0 1 0 0 1 1 1 0]
+
+	assert.EqualValues(t, 1000000000, cnt.Count())
+	assert.Equal(t, []int{0, 0, 0, 0, 0, 0, 1000000000, 0, 0, 0}, cnt.values)
 }


### PR DESCRIPTION
Hi,

I try to use circuit breaker and set the checkPeriod greater than 10 seconds.
My expectation was that the count would only reflect the values from the most recent 10 seconds.
However, the results didn't match my expectations.

I found that in the RollingCounter's cleanup method, the value of now appears to accumulate.
When lastUpdated is not the latest (e.g., from several seconds ago), it seems to result in some slots not being properly cleaned up.

I've proposed a fix in this pull request, and I'd appreciate it if you could review it.

Thank you for your time!

Best regards,
Mike