### PR TITLE
remove superflous WriteHeader call from buffer tests

### DIFF
--- a/buffer/buffer_test.go
+++ b/buffer/buffer_test.go
@@ -417,7 +417,6 @@ func TestBuffer_GRPC_OKResponse(t *testing.T) {
 	srv := testutils.NewHandler(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Grpc-Status", "0" /* OK */)
 		_, _ = w.Write([]byte("grpc-body"))
-		w.WriteHeader(http.StatusOK)
 
 		// To skip the "Content-Length" header.
 		w.(http.Flusher).Flush()


### PR DESCRIPTION
When running the tests for the buffer package with the `-v` flag, there is a log message that the call to `WriteHeader` from the `TestBuffer_GRPC_OKResponse` test is superfluous.

Before:
```
$ go test -v ./buffer -count=1 -run TestBuffer_GRPC_OKResponse
=== RUN   TestBuffer_GRPC_OKResponse
2024/12/16 11:55:54 http: superfluous response.WriteHeader call from github.com/vulcand/oxy/v2/buffer.TestBuffer_GRPC_OKResponse.func1 (buffer_test.go:420)
--- PASS: TestBuffer_GRPC_OKResponse (0.00s)
PASS
ok  	github.com/vulcand/oxy/v2/buffer	0.608s
```

After:
```
$ go test -v ./buffer -count=1 -run TestBuffer_GRPC_OKResponse
=== RUN   TestBuffer_GRPC_OKResponse
--- PASS: TestBuffer_GRPC_OKResponse (0.00s)
PASS
ok  	github.com/vulcand/oxy/v2/buffer	0.599s
```