### PR TITLE
remove unnecessary calls to time.Sleep func

### DIFF
--- a/internal/holsterv4/clock/system_test.go
+++ b/internal/holsterv4/clock/system_test.go
@@ -66,7 +66,6 @@ func TestTimerStop(t *testing.T) {
 
 	// Then
 	assert.Equal(t, true, active)
-	time.Sleep(100)
 	select {
 	case <-timer.C():
 		assert.Fail(t, "Timer should not have fired")
@@ -106,7 +105,6 @@ func TestNewTicker(t *testing.T) {
 	}
 
 	timer.Stop()
-	time.Sleep(150)
 	select {
 	case <-timer.C():
 		assert.Fail(t, "Ticker should not have fired")


### PR DESCRIPTION
this PR just removes calls to time.Sleep that are not needed in some test functions, 
they won't affect the test to fail or to pass, they are apparently useless.