### PR TITLE
fix: ensure bufferWriter returns an error when exceeding maxResponseBodyBytes

### DIFF
--- a/buffer/buffer_test.go
+++ b/buffer/buffer_test.go
@@ -2,6 +2,7 @@ package buffer
 
 import (
 	"bufio"
+	"crypto/rand"
 	"crypto/tls"
 	"fmt"
 	"io"
@@ -173,8 +174,11 @@ func TestBuffer_requestLimitReached(t *testing.T) {
 }
 
 func TestBuffer_responseLimitReached(t *testing.T) {
+	payload := make([]byte, 40000)
+	_, _ = rand.Read(payload)
+
 	srv := testutils.NewHandler(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte("hello, this response is too large"))
+		_, _ = w.Write(payload)
 	})
 	t.Cleanup(srv.Close)
 
@@ -188,7 +192,7 @@ func TestBuffer_responseLimitReached(t *testing.T) {
 	})
 
 	// stream handler will forward requests to redirect
-	st, err := New(rdr, MaxResponseBodyBytes(4))
+	st, err := New(rdr, MaxResponseBodyBytes(10000))
 	require.NoError(t, err)
 
 	proxy := httptest.NewServer(st)


### PR DESCRIPTION
### Description

This PR ensures that `bufferWriter` returns an error when the underlying writer fails.  
It fixes cases where the buffer incorrectly returns a 200 status code even when `maxResponseBodyBytes` is exceeded (see the unit test update for details).

related to https://github.com/vulcand/oxy/pull/247