### PR TITLE
fix: initialize Multibuf Response Writer before Reader 

### DIFF
--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -207,7 +207,7 @@ func (b *Buffer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 		var reader multibuf.MultiReader
 
-		if bw.expectBody(outReq) {
+		if bw.expectBody(outReq) && b.maxResponseBodyBytes > 0 && b.memResponseBodyBytes > 0 {
 			rdr, err := writer.Reader()
 			if err != nil {
 				b.log.Error("vulcand/oxy/buffer: failed to read response, err: %v", err)

--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -207,7 +207,14 @@ func (b *Buffer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 		var reader multibuf.MultiReader
 
-		if bw.expectBody(outReq) && b.maxResponseBodyBytes > 0 && b.memResponseBodyBytes > 0 {
+		if bw.expectBody(outReq) {
+			if _, err := writer.Write([]byte{}); err != nil {
+				b.log.Error("vulcand/oxy/buffer: failed to initialize response writer, err: %v", err)
+				b.errHandler.ServeHTTP(w, req, err)
+
+				return
+			}
+
 			rdr, err := writer.Reader()
 			if err != nil {
 				b.log.Error("vulcand/oxy/buffer: failed to read response, err: %v", err)

--- a/buffer/buffer_test.go
+++ b/buffer/buffer_test.go
@@ -152,6 +152,33 @@ func TestBuffer_chunkedResponse(t *testing.T) {
 	assert.Equal(t, strconv.Itoa(len("testtest1test2")), re.Header.Get("Content-Length"))
 }
 
+func TestBuffer_emptyChunkedResponse(t *testing.T) {
+	srv := testutils.NewHandler(func(w http.ResponseWriter, _ *http.Request) {
+		h := w.(http.Hijacker)
+		conn, _, _ := h.Hijack()
+		_, _ = fmt.Fprintf(conn, "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n")
+		_ = conn.Close()
+	})
+	t.Cleanup(srv.Close)
+
+	fwd := forward.New(false)
+
+	rdr := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		req.URL = testutils.MustParseRequestURI(srv.URL)
+		fwd.ServeHTTP(w, req)
+	})
+	st, err := New(rdr)
+	require.NoError(t, err)
+
+	proxy := httptest.NewServer(st)
+	t.Cleanup(proxy.Close)
+
+	re, body, err := testutils.Get(proxy.URL)
+	require.NoError(t, err)
+	assert.Empty(t, body)
+	assert.Equal(t, http.StatusOK, re.StatusCode)
+}
+
 func TestBuffer_requestLimitReached(t *testing.T) {
 	srv := testutils.NewHandler(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte("hello"))
@@ -495,31 +522,4 @@ func TestBuffer_GRPC_OKResponse(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, re.StatusCode)
 	assert.Equal(t, "grpc-body", string(body))
-}
-
-func TestEmptyChunkedResponse(t *testing.T) {
-	srv := testutils.NewHandler(func(w http.ResponseWriter, req *http.Request) {
-		h := w.(http.Hijacker)
-		conn, _, _ := h.Hijack()
-		_, _ = fmt.Fprintf(conn, "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n")
-		_ = conn.Close()
-	})
-	t.Cleanup(srv.Close)
-
-	fwd := forward.New(false)
-
-	rdr := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		req.URL = testutils.MustParseRequestURI(srv.URL)
-		fwd.ServeHTTP(w, req)
-	})
-	st, err := New(rdr)
-	require.NoError(t, err)
-	proxy := httptest.NewServer(st)
-
-	t.Cleanup(proxy.Close)
-
-	re, body, err := testutils.Get(proxy.URL)
-	require.NoError(t, err)
-	assert.Equal(t, "", string(body))
-	assert.Equal(t, http.StatusOK, re.StatusCode)
 }

--- a/buffer/buffer_test.go
+++ b/buffer/buffer_test.go
@@ -496,3 +496,30 @@ func TestBuffer_GRPC_OKResponse(t *testing.T) {
 	assert.Equal(t, http.StatusOK, re.StatusCode)
 	assert.Equal(t, "grpc-body", string(body))
 }
+
+func TestEmptyChunkedResponse(t *testing.T) {
+	srv := testutils.NewHandler(func(w http.ResponseWriter, req *http.Request) {
+		h := w.(http.Hijacker)
+		conn, _, _ := h.Hijack()
+		_, _ = fmt.Fprintf(conn, "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n")
+		_ = conn.Close()
+	})
+	t.Cleanup(srv.Close)
+
+	fwd := forward.New(false)
+
+	rdr := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		req.URL = testutils.MustParseRequestURI(srv.URL)
+		fwd.ServeHTTP(w, req)
+	})
+	st, err := New(rdr)
+	require.NoError(t, err)
+	proxy := httptest.NewServer(st)
+
+	t.Cleanup(proxy.Close)
+
+	re, body, err := testutils.Get(proxy.URL)
+	require.NoError(t, err)
+	assert.Equal(t, "", string(body))
+	assert.Equal(t, http.StatusOK, re.StatusCode)
+}


### PR DESCRIPTION
This will resolve #240 and as such, I've added @vincentob's test case.

The multibuf library appears to keep their own internal state of the `Writer` object. The 500s we were seeing were to to the `Writer` calling `Reader()` when it's still in the `writerInit` state.

 We can see that here: [Multibuf Buffer](https://github.com/mailgun/multibuf/blob/master/buffer.go?plain=1#L401) We can avoid this by initializing the writer by calling `Writer()`.

They handle the writerInit case in the writer function [here](https://github.com/mailgun/multibuf/blob/035c119f2a9be0e95b7aefe0c38c6e38266bf3a5/buffer.go?plain=1#L351)

Fixes #240