### PR TITLE
fix(memmetrics): protect RollingCounter against concurrent access

### DIFF
--- a/memmetrics/counter.go
+++ b/memmetrics/counter.go
@@ -2,6 +2,7 @@ package memmetrics
 
 import (
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/vulcand/oxy/v2/internal/holsterv4/clock"
@@ -11,6 +12,7 @@ type rcOption func(*RollingCounter) error
 
 // RollingCounter Calculates in memory failure rate of an endpoint using rolling window of a predefined size.
 type RollingCounter struct {
+	mu             sync.Mutex
 	resolution     time.Duration
 	values         []int
 	countedBuckets int // how many samples in different buckets have we collected so far
@@ -54,6 +56,8 @@ func (c *RollingCounter) Append(o *RollingCounter) error {
 
 // Clone clones a counter.
 func (c *RollingCounter) Clone() *RollingCounter {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.cleanup()
 	other := &RollingCounter{
 		resolution:  c.resolution,
@@ -68,6 +72,8 @@ func (c *RollingCounter) Clone() *RollingCounter {
 
 // Reset resets a counter.
 func (c *RollingCounter) Reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.lastBucket = -1
 	c.countedBuckets = 0
 
@@ -79,11 +85,15 @@ func (c *RollingCounter) Reset() {
 
 // CountedBuckets gets counted buckets.
 func (c *RollingCounter) CountedBuckets() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	return c.countedBuckets
 }
 
 // Count counts.
 func (c *RollingCounter) Count() int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.cleanup()
 	return c.sum()
 }
@@ -105,6 +115,8 @@ func (c *RollingCounter) WindowSize() time.Duration {
 
 // Inc increments counter.
 func (c *RollingCounter) Inc(v int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.cleanup()
 	c.incBucketValue(v)
 }


### PR DESCRIPTION
## Summary

`RollingCounter` is shared concurrently:

- `RTMetrics.Record(...)` calls `m.total.Inc(1)` and `m.netErrors.Inc(1)` from every request goroutine.
- `RTMetrics.NetworkErrorRatio()` calls `m.netErrors.Count()` and `m.total.Count()` from circuit-breaker condition evaluations.
- `RTMetrics.Reset()` clears the counters when the circuit breaker trips.

`RollingCounter` itself has no mutex. The race detector fires deterministically with 50+ goroutines: concurrent reads in `cleanup()`/`sum()` race with writes in `incBucketValue()` on the same `c.values` backing array. `Reset` is also unprotected against concurrent `Inc`/`Count`.

The circuit breaker reads these counters to make trip/recovery decisions; corrupt reads under load mean incorrect availability decisions.

## Fix

Add a `sync.Mutex` to `RollingCounter` and lock it in every public method:

- `Inc`
- `Count`
- `Reset`
- `Clone`
- `CountedBuckets`

`cleanup()`, `incBucketValue()`, and `sum()` remain unlocked private helpers — they are always invoked with the lock held.

## Verification

`go test -race ./...` is green with the fix across all packages (buffer, cbreaker, connlimit, forward, memmetrics, ratelimit, roundrobin, stream, trace, utils). The PoC test reproduces the race deterministically on master and passes after the patch.

## Severity

CRITICAL — production data race in a counter that drives circuit-breaker decisions. Any deployment using `cbreaker` or `RTMetrics` under load is affected.

## Proof of Concept

`RTMetrics` is used by the circuit breaker and exposed via roundtrip-metrics middleware. Every HTTP handler goroutine calls `RTMetrics.Record(...)` which fans out to `m.total.Inc(1)` and `m.netErrors.Inc(1)` on shared `RollingCounter` instances. `RollingCounter` has no internal synchronization: `Inc` writes to `c.values []int` (after `cleanup()` clears stale buckets), `Count` reads the slice via `sum()`, and `Reset` clears the slice. With concurrent traffic the race detector fires immediately. Worse, the circuit breaker reads these counters when evaluating trip conditions, so corrupted counts can produce incorrect trip/recovery decisions.

### Steps to Reproduce

```go
package memmetrics_test

import (
	"sync"
	"testing"
	"time"

	"github.com/vulcand/oxy/v2/memmetrics"
)

// Run with -race.
func TestRTMetricsDataRace(t *testing.T) {
	m, err := memmetrics.NewRTMetrics()
	if err != nil {
		t.Fatal(err)
	}
	var wg sync.WaitGroup
	for i := 0; i < 50; i++ {
		wg.Add(1)
		go func() {
			defer wg.Done()
			for j := 0; j < 200; j++ {
				m.Record(200, 10*time.Millisecond)
				m.Record(502, 5*time.Millisecond)
			}
		}()
	}
	wg.Add(1); go func() { defer wg.Done(); for i := 0; i < 30; i++ { m.Reset(); time.Sleep(time.Millisecond) } }()
	wg.Add(1); go func() { defer wg.Done(); for i := 0; i < 500; i++ { _ = m.NetworkErrorRatio() } }()
	wg.Wait()
}
```

Before fix: `go test -race` reports DATA RACE in `memmetrics/counter.go` (`Inc` vs `cleanup`/`sum`/`Reset`). After fix: clean.
