### PR TITLE
fix(buffer): close per-iteration buffers in retry loop to avoid temp-file leak

### DIFF
--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -212,7 +212,10 @@ func (b *Buffer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			responseWriter: w,
 			log:            b.log,
 		}
-		defer bw.Close()
+		// NOTE: bw.Close() is invoked explicitly at the end of each iteration
+		// rather than deferred. A defer here would only fire on function return,
+		// so up to DefaultMaxRetryAttempts (10) bufferWriters — each potentially
+		// holding a spilled-to-disk temp file — would stay live concurrently.
 
 		b.next.ServeHTTP(bw, outReq)
 
@@ -223,6 +226,7 @@ func (b *Buffer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 		if bw.writeError != nil {
 			b.log.Error("vulcand/oxy/buffer: failed to copy response, err: %v", bw.writeError)
+			_ = bw.Close()
 			b.errHandler.ServeHTTP(w, req, bw.writeError)
 
 			return
@@ -233,6 +237,7 @@ func (b *Buffer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		if bw.expectBody(outReq) {
 			if _, err := writer.Write([]byte{}); err != nil {
 				b.log.Error("vulcand/oxy/buffer: failed to initialize response writer, err: %v", err)
+				_ = bw.Close()
 				b.errHandler.ServeHTTP(w, req, err)
 
 				return
@@ -241,11 +246,11 @@ func (b *Buffer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			rdr, err := writer.Reader()
 			if err != nil {
 				b.log.Error("vulcand/oxy/buffer: failed to read response, err: %v", err)
+				_ = bw.Close()
 				b.errHandler.ServeHTTP(w, req, err)
 
 				return
 			}
-			defer rdr.Close()
 
 			reader = rdr
 		}
@@ -257,10 +262,20 @@ func (b *Buffer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 			if reader != nil {
 				_, _ = io.Copy(w, reader)
+				_ = reader.Close()
 			}
+			_ = bw.Close()
 
 			return
 		}
+
+		// Retry path: close per-iteration buffers before next attempt so that
+		// up to DefaultMaxRetryAttempts (10) spilled-to-disk temp files do not
+		// stay open simultaneously.
+		if reader != nil {
+			_ = reader.Close()
+		}
+		_ = bw.Close()
 
 		attempt++
 


### PR DESCRIPTION
## Summary

`buffer.go:215, 248` (in the `for` retry loop) use `defer` to close per-iteration resources:

```go
for {
    writer, err := multibuf.NewWriterOnce(...)
    ...
    bw := &bufferWriter{buffer: writer, ...}
    defer bw.Close()   // ← fires on function return, NOT on iteration end

    b.next.ServeHTTP(bw, outReq)
    ...

    if bw.expectBody(outReq) {
        ...
        rdr, err := writer.Reader()
        ...
        defer rdr.Close()   // ← same bug
    }

    if !retrying { return }
    attempt++
}
```

Each iteration adds another `Close` to the function's defer stack. When `multibuf.WriterOnce` spills to disk (which is the case for any response body larger than `memResponseBodyBytes`, default 1 MB), the temp file stays open until the handler returns — even on retried attempts whose buffer is no longer needed. With `DefaultMaxRetryAttempts = 10`, the worst case is 10 simultaneously-open temp files per in-flight request.

## Fix

Close per-iteration buffers explicitly:

- On the terminal (no-retry) path: close before the final `return`.
- On the retry path: close before incrementing `attempt`.
- On all error early-returns: close before invoking the error handler.

The deferred close is removed entirely — there are no exit paths now that fall through without an explicit close.

## Verification

`go test -race ./...` is green across all packages.

## Severity

HIGH — disk space + fd exhaustion under retry-heavy load. Subtle (no error, no log, the leak is "merely" too-many-open-files for a brief window). Easy fix.

## Proof of Concept

`buffer.Buffer.ServeHTTP` opens a `multibuf.WriterOnce` per attempt — which spills to a temp file when the in-memory limit is exceeded — and `defer bw.Close()` / `defer rdr.Close()` from inside the `for` retry loop. Go runs deferred functions on the enclosing function's return, not at the end of the loop iteration. With `DefaultMaxRetryAttempts = 10`, up to 10 spilled-to-disk temp files stay live concurrently across all retry attempts, even though only the last attempt's body is ever read. Under retry-heavy traffic this accumulates file descriptors per in-flight request.

### Steps to Reproduce

```go
// Structural test — verifies retries happen so the leak path is exercised.
// True observability of the leak requires fd / temp-file counting:
//   lsof -p <pid> | wc -l   (before & after the retry burst)

func TestBufferRetryHappens(t *testing.T) {
    var n int32
    backend := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
        c := atomic.AddInt32(&n, 1)
        if c <= 2 { w.WriteHeader(http.StatusBadGateway); return }
        w.WriteHeader(http.StatusOK); _, _ = w.Write([]byte("ok"))
    })
    buf, _ := buffer.New(backend,
        buffer.Retry(`IsNetworkError() && Attempts() <= 2`),
        buffer.MemResponseBodyBytes(1)) // force spill
    buf.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("POST", "/", strings.NewReader("hello")))
}
```
