### PR TITLE
fix(utils): use net.SplitHostPort for IPv6 RemoteAddr parsing

### DIFF
--- a/utils/source.go
+++ b/utils/source.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
 )
@@ -47,12 +48,16 @@ func NewExtractor(variable string) (SourceExtractor, error) {
 }
 
 func extractClientIP(req *http.Request) (string, int64, error) {
-	vals := strings.SplitN(req.RemoteAddr, ":", 2)
-	if vals[0] == "" {
+	// Use net.SplitHostPort to correctly handle bracketed IPv6 addresses
+	// (e.g. "[::1]:8080"). The previous strings.SplitN(":", 2) produced
+	// the literal "[" for any IPv6 client, collapsing all IPv6 callers
+	// into the same rate-limit / connection-limit bucket.
+	host, _, err := net.SplitHostPort(req.RemoteAddr)
+	if err != nil || host == "" {
 		return "", 0, fmt.Errorf("failed to parse client IP: %v", req.RemoteAddr)
 	}
 
-	return vals[0], 1, nil
+	return host, 1, nil
 }
 
 func extractHost(req *http.Request) (string, int64, error) {


### PR DESCRIPTION
## Summary

`utils/source.go:49-56` parses `req.RemoteAddr` for rate-limit / connection-limit / source-IP extraction:

```go
func extractClientIP(req *http.Request) (string, int64, error) {
    vals := strings.SplitN(req.RemoteAddr, ":", 2)
    if vals[0] == "" {
        return "", 0, fmt.Errorf("failed to parse client IP: %v", req.RemoteAddr)
    }
    return vals[0], 1, nil
}
```

For IPv4 (`192.0.2.1:8080`) this works. For IPv6 (`[::1]:8080`, `[fe80::1]:8080`, `[2001:db8::1]:443`) the SplitN on `:` returns the literal `"["` as the first element. Every IPv6 client is bucketed together under that one token. Anyone on the link can exhaust the bucket for everyone else, or fly under per-IP limits by selecting an IPv6 transport.

## Fix

Replace `strings.SplitN` with `net.SplitHostPort`. The stdlib function handles bracketed IPv6 notation correctly. Both IPv4 and IPv6 produce the correct host string. The error path remains identical.

## Verification

`go test -race ./...` is green across all packages.

## Severity

HIGH — per-IP rate-limit and connection-limit bypass for any IPv6 client. The bypass is "free" in the sense that no exotic header is needed — just an IPv6 connection. Trivial fix.

## Proof of Concept

`extractClientIP` parses `req.RemoteAddr` with `strings.SplitN(":", 2)`. For an IPv4 address `192.0.2.1:8080` this correctly returns `["192.0.2.1", "8080"]` and yields `"192.0.2.1"`. For an IPv6 address `[::1]:8080` it returns `["[", ":1]:8080"]` and yields `"["`. Every IPv6 client (loopback, link-local, global) is therefore reduced to the single literal token `"["` (or `"[fe80"` for some forms after partial parsing), collapsing all IPv6 clients into one rate-limit / connection-limit bucket. A single client can exhaust another's quota, or attackers can bypass per-IP limits by simply connecting over IPv6.

### Steps to Reproduce

```go
package utils_test

import (
	"net/http/httptest"
	"testing"

	"github.com/vulcand/oxy/v2/utils"
)

func TestExtractClientIPv6(t *testing.T) {
	extractor, _ := utils.NewExtractor("client.ip")
	cases := []struct{ remote, want string }{
		{"192.0.2.1:8080", "192.0.2.1"},
		{"[::1]:8080", "::1"},
		{"[fe80::1]:8080", "fe80::1"},
		{"[2001:db8::1]:443", "2001:db8::1"},
	}
	for _, tt := range cases {
		req := httptest.NewRequest("GET", "/", nil)
		req.RemoteAddr = tt.remote
		token, _, err := extractor.Extract(req)
		if err != nil || token != tt.want {
			t.Errorf("Extract(%q): token=%q want=%q err=%v", tt.remote, token, tt.want, err)
		}
	}
}
```

Before fix: IPv6 cases all return token `"["`. After fix: correct IPv6 host string.
